### PR TITLE
[수정] 깃헙 액션이 시크릿 변수에 접근할 수 있도록 변경

### DIFF
--- a/.github/workflows/pr_webhook.yml
+++ b/.github/workflows/pr_webhook.yml
@@ -1,7 +1,7 @@
 name: pr-webhook
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, closed]
 
 jobs:


### PR DESCRIPTION
## 📝 개요

- 깃헙 액션에서 시크릿 변수에 접근할 수 없어 발생하고 있는 오류 수정

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ 트리거 동작 방법을 `pull_request` 에서 `pull_request_target` 으로 변경

## ℹ️ 참고 사항

- 
