### PR TITLE
[기능 및 수정] 플랜 삭제 api 연결 및 플랜-코스로 공유 기능 구현

### DIFF
--- a/src/entities/plan/api.ts
+++ b/src/entities/plan/api.ts
@@ -40,3 +40,13 @@ export const updatePlan = async (id: string, payload: PlanPayloadType) => {
     throw error
   }
 }
+
+export const deletePlan = async (id: string) => {
+  try {
+    const response = await customAxios.delete(`/plans/${id}`)
+    return response.data.results
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/src/entities/plan/query.ts
+++ b/src/entities/plan/query.ts
@@ -6,6 +6,7 @@ import {
 } from '@tanstack/react-query'
 import { PlanPayloadType, PlanType } from '@/src/entities/plan/type'
 import {
+  deletePlan,
   getPlan,
   getPlans,
   postPlan,
@@ -49,6 +50,17 @@ export const useUpdatePlan = (id: string) => {
     mutationFn: (data: PlanPayloadType) => updatePlan(id, data),
     onSuccess: () => {
       queryClient.refetchQueries({ queryKey: PLAN_QUERY_KEY.detail(id) })
+    },
+  })
+}
+
+export const useDeletePlan = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: string) => deletePlan(id),
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: PLAN_QUERY_KEY.all })
     },
   })
 }

--- a/src/widgets/course-plan-detail-layout/index.tsx
+++ b/src/widgets/course-plan-detail-layout/index.tsx
@@ -148,31 +148,22 @@ export default function CoursePlanDetailLayout({
       {children}
       <Spacer height={25} />
       {!isCourse && (
-        <div className='w-full h-[54px] flex flex-row gap-[2px] text-brand font-bold text-main'>
-          <button
-            className='w-[187px] h-full flex items-center justify-center bg-light-gray   cursor-pointer gap-[10px] hover:bg-brand hover:text-white transition-all duration-200'
-            onClick={() => setIsClicked(!isClicked)}
-          >
-            {isClicked ? (
-              <>
-                <X size={24} strokeWidth={1.5} />
-                닫기
-              </>
-            ) : (
-              <>
-                <Share2 size={24} strokeWidth={1.5} />
-                공유하기
-              </>
-            )}
-          </button>
-          <Link
-            className='w-[187px] h-full flex items-center justify-center bg-light-gray gap-[10px] cursor-pointer hover:bg-brand hover:text-white transition-all duration-200'
-            href={`/${type}s/${id}/update`}
-          >
-            <PenLine size={24} strokeWidth={1.5} />
-            수정하기
-          </Link>
-        </div>
+        <button
+          className='w-full h-[54px] text-brand font-bold text-main flex items-center justify-center bg-light-gray cursor-pointer gap-[10px] hover:bg-brand hover:text-white transition-all duration-200'
+          onClick={() => setIsClicked(!isClicked)}
+        >
+          {isClicked ? (
+            <>
+              <X size={24} strokeWidth={1.5} />
+              닫기
+            </>
+          ) : (
+            <>
+              <Share2 size={24} strokeWidth={1.5} />
+              공유하기
+            </>
+          )}
+        </button>
       )}
       {isClicked && renderFloatingButtons()}
       {contextHolder}

--- a/src/widgets/course-plan-detail-layout/index.tsx
+++ b/src/widgets/course-plan-detail-layout/index.tsx
@@ -66,14 +66,18 @@ export default function CoursePlanDetailLayout({
     setIsClicked(!isClicked)
   }
 
+  const handleClickShareCourse = () => {
+    setIsClicked(!isClicked)
+    sessionStorage.setItem('course', JSON.stringify(data))
+
+    handleClick('/courses/new')
+  }
+
   const renderFloatingButtons = () =>
     isClicked && (
       <div className='flex flex-col gap-[5px] absolute bottom-[120px]'>
         <FloatingMenuButton onClick={copyToClipboard} text='링크 복사' />
-        <FloatingMenuButton
-          onClick={() => handleClick('/courses/new')}
-          text='코스 작성'
-        />
+        <FloatingMenuButton onClick={handleClickShareCourse} text='코스 작성' />
       </div>
     )
 

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -85,11 +85,10 @@ export default function CoursePlanFormLayout({
     },
   })
 
-  const fetchData = id
-    ? type === LAYOUT_TYPE.course
-      ? useGetCourse(id)
-      : useGetPlan(id)
-    : null
+  const getData = useMemo(() => {
+    return id && type === LAYOUT_TYPE.course ? useGetCourse : useGetPlan
+  }, [id, type])
+  const fetchData = getData(id || '') || null
 
   useEffect(() => {
     if (level === LEVEL_TYPE.update) {

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -85,10 +85,11 @@ export default function CoursePlanFormLayout({
     },
   })
 
-  const getData = useMemo(() => {
-    return id && type === LAYOUT_TYPE.course ? useGetCourse : useGetPlan
-  }, [id, type])
-  const fetchData = getData(id || '') || null
+  const fetchData = id
+    ? type === LAYOUT_TYPE.course
+      ? useGetCourse(id)
+      : useGetPlan(id)
+    : null
 
   useEffect(() => {
     if (level === LEVEL_TYPE.update) {
@@ -107,6 +108,27 @@ export default function CoursePlanFormLayout({
       }
     }
   }, [level, type, fetchData])
+
+  useEffect(() => {
+    if (level === LEVEL_TYPE.add && type === LAYOUT_TYPE.course) {
+      const storedData = sessionStorage.getItem('course')
+      if (storedData) {
+        const course = JSON.parse(storedData)
+        setValue('title', course.title)
+        setValue('primary_region', course.primary_region)
+        setValue('secondary_region', course.secondary_region)
+        setValue('categories', course.categories)
+        setValue('contents', course.contents)
+        setValue('visit_date', course.visit_date)
+        setPlaces(course.places || [])
+
+        setIsDataLoaded(true)
+      }
+    }
+    return () => {
+      sessionStorage.removeItem('course')
+    }
+  }, [level, type])
 
   const { mutate: courseMutate } = useCreateCourse()
   const { mutate: planMutate } = useCreatePlan()
@@ -185,13 +207,31 @@ export default function CoursePlanFormLayout({
     'secondary_region'
   )}`
 
+  const isCourseSessionStored = !!sessionStorage.getItem('course')
+  const shouldRenderForm = (() => {
+    if (level === LEVEL_TYPE.update) {
+      return isDataLoaded
+    }
+
+    if (level === LEVEL_TYPE.add) {
+      if (type === LAYOUT_TYPE.plan) {
+        return true
+      }
+
+      if (type === LAYOUT_TYPE.course) {
+        return !isCourseSessionStored || (isCourseSessionStored && isDataLoaded)
+      }
+    }
+
+    return false
+  })()
+
   return (
     <div className='relative h-100% flex flex-col'>
       <Header title={headerTitle} isBack />
       <Spacer height={25} />
       <form onSubmit={handleSubmit(onSubmit)}>
-        {((level === LEVEL_TYPE.update && isDataLoaded) ||
-          level === LEVEL_TYPE.add) && (
+        {shouldRenderForm && (
           <FormSections
             pageType={pageType}
             register={register}

--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/src/entities/course/query'
 import { useQueryClient } from '@tanstack/react-query'
 import { COURSE_QUERY_KEY } from '@/src/entities/course/query'
+import { useDeletePlan } from '@/src/entities/plan/query'
 
 interface HeaderProps {
   title: string
@@ -125,7 +126,8 @@ export function OptionHeader({
 
   const { mutate: deleteCourseLike } = useDeleteCourseLike(id)
   const { mutate: postCourseLike } = usePostCourseLike(id)
-  const { mutate: deleteCourse } = useDeleteCourse()
+  const { mutate: deleteCourseOrPlan } =
+    type === 'course' ? useDeleteCourse() : useDeletePlan()
 
   const myId = useUserStore((state) => state.user?.user_id)
 
@@ -161,7 +163,7 @@ export function OptionHeader({
   const handleDelete = async () => {
     try {
       if (myId) {
-        deleteCourse(id, {
+        deleteCourseOrPlan(id, {
           onSuccess: () => {
             router.push(`/${type}s`)
             queryClient.invalidateQueries({

--- a/src/widgets/header/index.tsx
+++ b/src/widgets/header/index.tsx
@@ -126,8 +126,10 @@ export function OptionHeader({
 
   const { mutate: deleteCourseLike } = useDeleteCourseLike(id)
   const { mutate: postCourseLike } = usePostCourseLike(id)
-  const { mutate: deleteCourseOrPlan } =
-    type === 'course' ? useDeleteCourse() : useDeletePlan()
+  const { mutate: deleteCourse } = useDeleteCourse()
+  const { mutate: deletePlan } = useDeletePlan()
+
+  const deleteCourseOrPlan = type === 'course' ? deleteCourse : deletePlan
 
   const myId = useUserStore((state) => state.user?.user_id)
 


### PR DESCRIPTION
## 📝 개요

- 플랜 삭제 및 코스로 공유 기능 구현을 위한 PR

## ✨ 변경 사항

  - ✨ 플랜 삭제 api 연결
  - ✨ 플랜 공유/수정/삭제 모달 수정
  - ✨ 플랜-코스로 공유 기능 구현
 
## 📸 스크린샷 (옵션)

https://github.com/user-attachments/assets/8c0a29d2-d257-4420-879f-75d4c74bf9a9



## ℹ️ 참고 사항

- 코스로 공유할 때 세션스토리지에 한 이유는 영구 저장까지는 할 필요 없을 것 같아서 세션으로 했습니다
- 코스 생성 페이지에서 이탈 시(뒤로가기, 생성 완료 후 페이지 이동 등등) 세션스토리지 비우게 했어요
