### PR TITLE
[수정] 유저 위시리스트 로직 수정 및 컴포넌트 분리

### DIFF
--- a/app/users/[id]/wishlist/page.tsx
+++ b/app/users/[id]/wishlist/page.tsx
@@ -1,5 +1,5 @@
-import ListCourse from '@/src/views/list-course'
+import ListLikeCourse from '@/src/views/list-like-course'
 
-export default async function Page() {
-  return <ListCourse title='관심 목록' />
+export default async function Page({ params }: { params: { id: string } }) {
+  return <ListLikeCourse id={params.id} />
 }

--- a/src/entities/course/query.ts
+++ b/src/entities/course/query.ts
@@ -34,7 +34,8 @@ export const COURSE_QUERY_KEY = {
       params.secondary_region,
     ] as const,
   detail: (id: string) => ['course', id] as const,
-  myLikeCourse: ['myLikeCourse'] as const,
+  likeCourse: (params: { id: string; order?: 'recent' | 'popular' }) =>
+    ['likeCourse', params.id, params.order] as const,
   userCourses: (id: string, order?: 'recent' | 'popular') =>
     ['userCourses', id, order] as const,
 }
@@ -81,12 +82,13 @@ export const useUpdateCourse = (id: string) => {
   })
 }
 
-export const useGetMyLikeCourses = (params: {
+export const useGetLikeCourses = (params: {
   id: string
   limit?: number
+  order?: 'recent' | 'popular'
 }): UseQueryResult<CourseType[]> => {
   return useQuery({
-    queryKey: COURSE_QUERY_KEY.myLikeCourse,
+    queryKey: COURSE_QUERY_KEY.likeCourse(params),
     queryFn: () => getMyLikeCourses(params),
     staleTime: 0,
     refetchOnWindowFocus: true,

--- a/src/features/main/section-like-course.tsx
+++ b/src/features/main/section-like-course.tsx
@@ -6,7 +6,7 @@ import GridCourse from '@/src/features/course/grid-course'
 import { CourseType } from '@/src/entities/course/type'
 import NoLikedCourse from '@/src/shared/ui/NoLikedCourse'
 import { useGetMyProfile } from '@/src/entities/user/query'
-import { useGetMyLikeCourses } from '@/src/entities/course/query'
+import { useGetLikeCourses } from '@/src/entities/course/query'
 import { getLoginUrl } from '@/src/entities/login/api'
 import { useRouter } from 'next/navigation'
 
@@ -38,7 +38,7 @@ export default function SectionLikeCourse() {
 }
 
 function UserLikeCourse({ id }: { id: string }) {
-  const { data: likeCourse } = useGetMyLikeCourses({ id, limit: 4 })
+  const { data: likeCourse } = useGetLikeCourses({ id, limit: 4 })
 
   if (!likeCourse || likeCourse.length === 0) return <NoLikedCourse />
 

--- a/src/shared/ui/NoLikedCourse.tsx
+++ b/src/shared/ui/NoLikedCourse.tsx
@@ -5,10 +5,10 @@ export default function NoLikedCourse() {
     <div className='w-full h-[180px] flex items-center justify-center'>
       <div className='flex flex-col shadow-lg w-[280px] h-[130px] rounded-[10px] items-center justify-center'>
         <span className='text-[14px] font-bold text-black'>
-          관심있는 코스가 없어요.
+          유저의 관심있는 코스가 없어요.
         </span>
         <span className='text-[13px]  text-black'>
-          인기있는 코스를 구경하고 추가해보세요!
+          인기있는 코스를 구경하러 가볼까요?
         </span>
         <Link
           href='/courses'

--- a/src/shared/ui/RegionCascader.tsx
+++ b/src/shared/ui/RegionCascader.tsx
@@ -90,17 +90,19 @@ export default function RegionCascaderWithLikes({
     )
 
   return (
-    <Cascader
-      options={options}
-      placeholder={placeholder}
-      onChange={onChange}
-      size='large'
-      showSearch={{ filter }}
-      style={{
-        width: '100%',
-      }}
-      expandTrigger='hover'
-    />
+    <div className='w-full px-[10px]'>
+      <Cascader
+        options={options}
+        placeholder={placeholder}
+        onChange={onChange}
+        size='large'
+        showSearch={{ filter }}
+        style={{
+          width: '100%',
+        }}
+        expandTrigger='hover'
+      />
+    </div>
   )
 }
 

--- a/src/shared/ui/SelectCategories.tsx
+++ b/src/shared/ui/SelectCategories.tsx
@@ -42,7 +42,7 @@ export default function SelectCategories({
     <div
       className={`flex gap-[3px] text-[13px] ${
         isList
-          ? 'w-full h-[50px] items-center overflow-x-auto border-b border-container-blue whitespace-nowrap'
+          ? 'w-full h-[50px] px-[10px] items-center overflow-x-auto border-b border-container-blue whitespace-nowrap'
           : 'flex-wrap'
       }`}
     >

--- a/src/views/list-like-course/index.tsx
+++ b/src/views/list-like-course/index.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useGetLikeCourses } from '@/src/entities/course/query'
+import Header from '@/src/widgets/header'
+import SelectCategories from '@/src/shared/ui/SelectCategories'
+import Spacer from '@/src/shared/ui/Spacer'
+import CourseListLayout from '@/src/widgets/course-list-layout'
+import { Select } from 'antd'
+import { useState } from 'react'
+import NoLikedCourse from '@/src/shared/ui/NoLikedCourse'
+
+interface ListLikeCourseProps {
+  id: string
+}
+
+export default function ListLikeCourse({ id }: ListLikeCourseProps) {
+  const [isListView, setIsListView] = useState(true)
+  const [category, setCategory] = useState<string[]>(['ALL'])
+  const [order, setOrder] = useState('recent')
+
+  const { data: likeCourses, isLoading } = useGetLikeCourses({
+    id,
+    order: order as 'recent' | 'popular',
+  })
+
+  if (isLoading) return <div>Loading...</div>
+
+  return (
+    <div>
+      <Header
+        title={'관심 목록'}
+        isHeart={false}
+        isLiked={false}
+        isTitleTag={true}
+        isBack
+        isListView={isListView}
+        setIsListView={setIsListView}
+      />
+      <SelectCategories
+        isList={true}
+        prevCategories={category}
+        setCategories={(category: string[]) => {
+          setCategory(category)
+        }}
+      />
+      <Spacer height={10} />
+      <div className='w-full flex px-[10px] justify-end items-center'>
+        <Select
+          defaultValue='recent'
+          style={{ width: 80 }}
+          onChange={(value) => setOrder(value)}
+          size={'small'}
+          options={[
+            { value: 'recent', label: '최신순' },
+            { value: 'popular', label: '인기순' },
+          ]}
+        />
+      </div>
+      {likeCourses?.length === 0 ? (
+        <NoLikedCourse />
+      ) : (
+        <CourseListLayout isListView={isListView} courses={likeCourses || []} />
+      )}
+    </div>
+  )
+}

--- a/src/views/main-course/index.tsx
+++ b/src/views/main-course/index.tsx
@@ -29,7 +29,7 @@ export default function MainCourse() {
   }
 
   return (
-    <div className='w-full h-full py-[20px] flex flex-col'>
+    <div className='w-full h-full py-[10px] flex flex-col'>
       <RegionCascaderWithLikes
         setRegion={onChangeRegion}
         placeholder='관심 지역 등록하고 빠르게 코스들 구경해요'
@@ -41,10 +41,8 @@ export default function MainCourse() {
           })) || []
         }
       />
-
       <Spacer height={11} />
       <Spacer className='bg-bright-gray' height={8} />
-
       <div className='flex flex-col w-full px-[20px]'>
         <div className='flex flex-col mt-[15px] justify-start'>
           <span className='text-headline font-bold text-brand'>

--- a/src/widgets/course-list-layout/index.tsx
+++ b/src/widgets/course-list-layout/index.tsx
@@ -14,7 +14,7 @@ export default function CourseListLayout({
   courses,
 }: CourseListLayoutProps) {
   return isListView ? (
-    <div className='flex flex-col justify-between items-center px-[10px]'>
+    <div className='flex flex-col justify-between items-center px-[20px]'>
       {courses.map((course: CourseType) => (
         <Fragment key={course.id}>
           <CardListCourse course={course} />


### PR DESCRIPTION
## 📝 개요

- 이 PR은 유저 위시리스트 로직 수정 및 컴포넌트 분리를 위한 PR입니다.

## ✨ 변경 사항

  - ✨ 유저 위시리스트 로직 수정
  - ✨ 유저 위시리스트 컴포넌트 분리
  - ✨ ui 이상함 수정

## ℹ️ 참고 사항

- 위시리스트 쿼리가 본인의 위시리스트를 보여주는 쿼리로 작성되어 있음
   - 로직 수정: path에 위치해있는 유저의 위시리스트를 보여주는 것으로 변경
- padding 없는 부분, ui 이상한 부분 수정
- listcourse 에서 컴포넌트 분리 -> 복잡도 개선
