### PR TITLE
[기능 및 수정] 플랜 목록이 비어있는 경우, 안내 문구와 플로팅 버튼의 겹침 해결

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,14 +11,12 @@
 
 html {
   background-color: var(--white);
-  /* font-size: 62.5%; */
   color: var(--black);
 }
 
 body {
   height: 100%;
   color: var(--black);
-  /* font-family: Arial, Helvetica, sans-serif; */
   font-family: Pretendard;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,14 +11,15 @@
 
 html {
   background-color: var(--white);
-  font-size: 62.5%;
+  /* font-size: 62.5%; */
   color: var(--black);
 }
 
 body {
   height: 100%;
   color: var(--black);
-  font-family: Arial, Helvetica, sans-serif;
+  /* font-family: Arial, Helvetica, sans-serif; */
+  font-family: Pretendard;
 }
 
 image {

--- a/src/features/plan/blank-tooltip.tsx
+++ b/src/features/plan/blank-tooltip.tsx
@@ -1,19 +1,38 @@
 export default function BlankTooltip() {
-
   return (
     <div className='flex relative justify-center items-center w-full'>
-      <div className="fixed top-[529px] inline-flex flex-col items-center">
-        <div className="w-[285px] h-auto p-[16px] bg-white rounded-2xl shadow-[0px_2px_7px_0px_rgba(0,0,0,0.12)] flex flex-col justify-start items-center gap-[8px]">
-          <div className="text-center h-[24px] text-black text-[20px] font-bold">
+      <div className='fixed bottom-[130px] inline-flex flex-col items-center'>
+        <div className='w-[285px] h-auto p-[16px] bg-white rounded-2xl shadow-[0px_2px_7px_0px_rgba(0,0,0,0.12)] flex flex-col justify-start items-center gap-[8px]'>
+          <div className='text-center h-[24px] text-black text-headline font-bold'>
             가고 싶은 곳들을 하나로!
           </div>
-          <div className="text-center h-[36px] text-[#333333] text-[14px] font-medium">
+          <div className='text-center h-[36px] text-[#333333] text-middle font-medium'>
             내 손으로 고른 장소들, <br /> 미리 계획하고 저장해볼까요?
           </div>
         </div>
-        <div className="absolute bottom-[-15px] right-4 ">
-          <svg width="21" height="16" viewBox="0 0 21 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12.3397 15C11.5699 16.3333 9.64544 16.3333 8.87564 15L0.215393 0L21 0L12.3397 15Z" fill="white"/>
+        <div className='absolute bottom-[-15px] right-4  '>
+          <svg
+            width='25'
+            height='20'
+            viewBox='-2 -2 25 20'
+            fill='none'
+            xmlns='http://www.w3.org/2000/svg'
+          >
+            <defs>
+              <filter id='shadow' x='0' y='0' width='200%' height='200%'>
+                <feDropShadow
+                  dx='0'
+                  dy='2'
+                  stdDeviation='2'
+                  floodOpacity={0.12}
+                />
+              </filter>
+            </defs>
+            <path
+              d='M12.3397 15C11.5699 16.3333 9.64544 16.3333 8.87564 15L0.215393 0L21 0L12.3397 15Z'
+              fill='white'
+              filter='url(#shadow)'
+            />
           </svg>
         </div>
       </div>

--- a/src/features/plan/blank-tooltip.tsx
+++ b/src/features/plan/blank-tooltip.tsx
@@ -1,13 +1,7 @@
 export default function BlankTooltip() {
 
   return (
-    <div className='flex relative justify-center items-center w-full h-[740px]'>
-      <div className="h-[37px] p-2.5 justify-center items-center gap-2.5 inline-flex">
-        <div className="text-center text-black text-[14px] font-medium">
-          아직 플랜이 없어요!
-        </div>
-      </div>
-      
+    <div className='flex relative justify-center items-center w-full'>
       <div className="fixed top-[529px] inline-flex flex-col items-center">
         <div className="w-[285px] h-auto p-[16px] bg-white rounded-2xl shadow-[0px_2px_7px_0px_rgba(0,0,0,0.12)] flex flex-col justify-start items-center gap-[8px]">
           <div className="text-center h-[24px] text-black text-[20px] font-bold">

--- a/src/features/plan/blank-tooltip.tsx
+++ b/src/features/plan/blank-tooltip.tsx
@@ -1,33 +1,28 @@
-import { Tooltip } from 'antd'
-
 export default function BlankTooltip() {
-  const content = (
-    <div className='flex flex-col items-center gap-[8px] text-center py-[10px] mx-[50px] whitespace-nowrap'>
-      <span className='text-headline font-bold text-[#333333]'>
-        가고 싶은 곳들을 하나로!
-      </span>
-      <span className='text-middle text-description'>
-        <p>내 손으로 고른 장소들</p>
-        <p>미리 계획하고 저장해볼까요?</p>
-      </span>
-    </div>
-  )
 
   return (
-    <div className='flex relative justify-center items-center w-full h-full'>
-      <span className='text-middle text-description w-full text-center'>
-        아직 플랜이 없어요!
-      </span>
-
-      <Tooltip
-        title={content}
-        color='white'
-        placement='topRight'
-        open
-        zIndex={1}
-      >
-        <div className='absolute bottom-[100px] right-[25px]' />
-      </Tooltip>
+    <div className='flex relative justify-center items-center w-full h-[740px]'>
+      <div className="h-[37px] p-2.5 justify-center items-center gap-2.5 inline-flex">
+        <div className="text-center text-black text-[14px] font-medium">
+          아직 플랜이 없어요!
+        </div>
+      </div>
+      
+      <div className="fixed top-[529px] inline-flex flex-col items-center">
+        <div className="w-[285px] h-auto p-[16px] bg-white rounded-2xl shadow-[0px_2px_7px_0px_rgba(0,0,0,0.12)] flex flex-col justify-start items-center gap-[8px]">
+          <div className="text-center h-[24px] text-black text-[20px] font-bold">
+            가고 싶은 곳들을 하나로!
+          </div>
+          <div className="text-center h-[36px] text-[#333333] text-[14px] font-medium">
+            내 손으로 고른 장소들, <br /> 미리 계획하고 저장해볼까요?
+          </div>
+        </div>
+        <div className="absolute bottom-[-15px] right-4 ">
+          <svg width="21" height="16" viewBox="0 0 21 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12.3397 15C11.5699 16.3333 9.64544 16.3333 8.87564 15L0.215393 0L21 0L12.3397 15Z" fill="white"/>
+          </svg>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/views/list-plan/index.tsx
+++ b/src/views/list-plan/index.tsx
@@ -10,11 +10,12 @@ import { useGetPlans } from '@/src/entities/plan/query'
 import { getLoginUrl } from '@/src/entities/login/api'
 import { useRouter } from 'next/navigation'
 import { useGetMyProfile } from '@/src/entities/user/query'
+import { useState } from 'react'
 
 export default function ListPlan() {
   const { data: plans } = useGetPlans()
   const { data: user } = useGetMyProfile()
-
+  const [isClick, setIsClick] = useState(false)
   const router = useRouter()
   const handleLogin = async () => {
     const loginUrl = await getLoginUrl()
@@ -42,7 +43,7 @@ export default function ListPlan() {
     )
 
   return (
-    <div className='w-full h-[calc(100vh-60px)] pt-[20px] pb-[20px] flex flex-col'>
+    <div className='w-full pt-[20px] pb-[20px] flex flex-col'>
       <div className='flex flex-col px-[16px]'>
         <span className='text-[14px] text-black'>
           좋아하는 장소들로 채우는 나만의 코스 계획
@@ -70,10 +71,17 @@ export default function ListPlan() {
           ))}
         </div>
       ) : (
-        <BlankTooltip />
+        <>
+          <div className="mt-[150px] h-full">
+            <div className="text-center text-black text-[14px] font-medium">
+              아직 플랜이 없어요!
+            </div>
+          </div>
+          {!isClick && <BlankTooltip />}        
+        </>
       )}
 
-      <FloatingWriteButton />
+      <FloatingWriteButton isClick={isClick} setIsClick={setIsClick}/>
     </div>
   )
 }

--- a/src/views/list-plan/index.tsx
+++ b/src/views/list-plan/index.tsx
@@ -43,12 +43,12 @@ export default function ListPlan() {
     )
 
   return (
-    <div className='w-full pt-[20px] pb-[20px] flex flex-col'>
+    <div className='w-full flex flex-col'>
+      <Spacer height={20} />
       <div className='flex flex-col px-[16px]'>
         <span className='text-[14px] text-black'>
           좋아하는 장소들로 채우는 나만의 코스 계획
         </span>
-
         <div className='flex justify-between items-center my-[5px]'>
           <span className='inline-flex items-center'>
             <p className='font-bold text-brand text-[20px]'>{user?.name}</p>
@@ -72,16 +72,17 @@ export default function ListPlan() {
         </div>
       ) : (
         <>
-          <div className="mt-[150px] h-full">
-            <div className="text-center text-black text-[14px] font-medium">
+          <div className='mt-[150px] h-full'>
+            <div className='text-center text-black text-[14px] font-medium'>
               아직 플랜이 없어요!
             </div>
           </div>
-          {!isClick && <BlankTooltip />}        
+          {!isClick && <BlankTooltip />}
         </>
       )}
+      <Spacer height={20}/>
 
-      <FloatingWriteButton isClick={isClick} setIsClick={setIsClick}/>
+      <FloatingWriteButton isClick={isClick} setIsClick={setIsClick} />
     </div>
   )
 }

--- a/src/views/list-plan/index.tsx
+++ b/src/views/list-plan/index.tsx
@@ -72,15 +72,14 @@ export default function ListPlan() {
         </div>
       ) : (
         <>
-          <div className='mt-[150px] h-full'>
-            <div className='text-center text-black text-[14px] font-medium'>
-              아직 플랜이 없어요!
-            </div>
+          <Spacer height={100}/>
+          <div className='text-center text-black text-[14px] font-medium'>
+            아직 플랜이 없어요!
           </div>
           {!isClick && <BlankTooltip />}
         </>
       )}
-      <Spacer height={20}/>
+      <Spacer height={20} />
 
       <FloatingWriteButton isClick={isClick} setIsClick={setIsClick} />
     </div>

--- a/src/widgets/floating-write-btn/index.tsx
+++ b/src/widgets/floating-write-btn/index.tsx
@@ -4,12 +4,12 @@ import { Pencil } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 
-type FloatingButtonProps = {
+interface FloatingButtonProps {
   onClick: () => void
   text: string
 }
 
-type FloatingWriteButtonProps = {
+interface FloatingWriteButtonProps {
   isClick: boolean
   setIsClick: (value: boolean) => void
 }

--- a/src/widgets/floating-write-btn/index.tsx
+++ b/src/widgets/floating-write-btn/index.tsx
@@ -2,16 +2,20 @@
 
 import { Pencil } from 'lucide-react'
 import { useRouter } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 
 type FloatingButtonProps = {
   onClick: () => void
   text: string
 }
 
-export default function FloatingWriteButton() {
+type FloatingWriteButtonProps = {
+  isClick: boolean
+  setIsClick: (value: boolean) => void
+}
+
+export default function FloatingWriteButton({ isClick, setIsClick } : FloatingWriteButtonProps) {
   const router = useRouter()
-  const [isClick, setIsClick] = useState(false)
 
   useEffect(() => {
     if (isClick) {


### PR DESCRIPTION
## ✨ 변경 사항

  - ✨ tooltip component 탈 antd
  - ✨ floating button의 isClick 함수를 lifting해 상태 전달

## 🔗 관련 이슈

- 이 PR과 관련된 이슈 번호를 연결합니다. (없으면 생략)
  - #124 

## 📸 스크린샷 (옵션)

- 기존
![image](https://github.com/user-attachments/assets/04eaad53-04da-435e-b8fb-59fed3ea9a2e)

- 기획
![image](https://github.com/user-attachments/assets/e0f7e85a-d2ef-4bca-8278-4d7ada5af72b)

- 수정
![image](https://github.com/user-attachments/assets/493d23ff-f37a-482a-85a4-950515c21a33)

