### PR TITLE
[수정] 리스트뷰 옵션 정보 임시 저장

### DIFF
--- a/src/views/list-course/index.tsx
+++ b/src/views/list-course/index.tsx
@@ -30,6 +30,13 @@ export default function ListCourse() {
     setIsLiked(!!regionId)
   }, [likedRegions, currentRegion])
 
+  useEffect(() => {
+    const isListView = sessionStorage.getItem('is-list')
+    if (isListView) {
+      setIsListView(isListView === 'true')
+    }
+  }, [])
+
   const { mutate: postLikeMutate } = usePostMyLikeRegion()
   const { mutate: deleteLikeMutate } = useDeleteMyLikeRegion()
 
@@ -69,6 +76,11 @@ export default function ListCourse() {
     }
   }
 
+  const handleSetIsListView = (isListView: boolean) => {
+    setIsListView(isListView)
+    sessionStorage.setItem('is-list', String(isListView))
+  }
+
   if (isLoading) return <div>Loading...</div>
 
   return (
@@ -78,7 +90,7 @@ export default function ListCourse() {
         isTitleTag={true}
         isBack
         isListView={isListView}
-        setIsListView={setIsListView}
+        setIsListView={handleSetIsListView}
         isHeart={true}
         isLiked={isLiked}
         setIsLiked={handleClickLike}
@@ -104,7 +116,7 @@ export default function ListCourse() {
         />
       </div>
       <CourseListLayout isListView={isListView} courses={courses} />
-      <FloatingWriteButton/>
+      <FloatingWriteButton />
     </div>
   )
 }

--- a/src/views/list-like-course/index.tsx
+++ b/src/views/list-like-course/index.tsx
@@ -6,7 +6,7 @@ import SelectCategories from '@/src/shared/ui/SelectCategories'
 import Spacer from '@/src/shared/ui/Spacer'
 import CourseListLayout from '@/src/widgets/course-list-layout'
 import { Select } from 'antd'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import NoLikedCourse from '@/src/shared/ui/NoLikedCourse'
 
 interface ListLikeCourseProps {
@@ -18,10 +18,22 @@ export default function ListLikeCourse({ id }: ListLikeCourseProps) {
   const [category, setCategory] = useState<string[]>(['ALL'])
   const [order, setOrder] = useState('recent')
 
+  useEffect(() => {
+    const isListView = sessionStorage.getItem('is-list-like')
+    if (isListView) {
+      setIsListView(isListView === 'true')
+    }
+  }, [])
+
   const { data: likeCourses, isLoading } = useGetLikeCourses({
     id,
     order: order as 'recent' | 'popular',
   })
+
+  const handleSetIsListView = (isListView: boolean) => {
+    setIsListView(isListView)
+    sessionStorage.setItem('is-list-like', String(isListView))
+  }
 
   if (isLoading) return <div>Loading...</div>
 
@@ -34,7 +46,7 @@ export default function ListLikeCourse({ id }: ListLikeCourseProps) {
         isTitleTag={true}
         isBack
         isListView={isListView}
-        setIsListView={setIsListView}
+        setIsListView={handleSetIsListView}
       />
       <SelectCategories
         isInCourseList={true}


### PR DESCRIPTION
## 📝 개요

- 리스트뷰 옵션 정보 저장을 위한 PR

## ✨ 변경 사항

  - ✨ 코스 상세 조회 후 다시 목록 페이지 접속 시, 설정했던 뷰 옵션(리스트, 그리드)으로 표시

## 🔗 관련 이슈

- closes #103 
