### PR TITLE
hotfix: default-card.tsx course or plan 로직 버그 수정

### DIFF
--- a/src/features/course-plan-card/ui/default-card.tsx
+++ b/src/features/course-plan-card/ui/default-card.tsx
@@ -8,7 +8,7 @@ interface CoursePlanCardProps {
 }
 
 export function CoursePlanCard({ data }: CoursePlanCardProps) {
-  const to = 'course_id' in data ? `/courses/${data.id}` : `/plans/${data.id}`
+  const to = 'categories' in data ? `/courses/${data.id}` : `/plans/${data.id}`
 
   return (
     <Link


### PR DESCRIPTION
## 📝 개요

- 메인 페이지 추천 코스 목록의 카드 하이퍼링크가 plan/id로 걸린 버그 수정

## ✨ 변경 사항

- CoursePlanCard 컴포넌트 내부의 to 속성을 props의 categories key가 존재하는지 여부로 판정
- (기존에는 course_id 여부로 판정했지만, 해당 필드는 존재하지 않음)

  
## 📸 스크린샷 (옵션)

![image](https://github.com/user-attachments/assets/6c2a1c50-c31c-41aa-81d2-19f900d2d6dc)


