### PR TITLE
 [수정-관심 목록] 알림 문구 명칭 변경

### DIFF
--- a/src/shared/ui/NoLikedCourse.tsx
+++ b/src/shared/ui/NoLikedCourse.tsx
@@ -5,7 +5,7 @@ export default function NoLikedCourse() {
     <div className='w-full h-[180px] flex items-center justify-center'>
       <div className='flex flex-col shadow-lg w-[280px] h-[130px] rounded-[10px] items-center justify-center'>
         <span className='text-[14px] font-bold text-black'>
-          유저의 관심있는 코스가 없어요.
+          아직 관심있는 코스가 없어요.
         </span>
         <span className='text-[13px]  text-black'>
           인기있는 코스를 구경하러 가볼까요?


### PR DESCRIPTION
## 📝 개요

-  ✨텍스트 메시지 변경
-  유저의 -> 아직


## 🔗 관련 이슈

  - #131 

## 📸 스크린샷 (옵션)


![image](https://github.com/user-attachments/assets/930dcc24-fdfc-4a8e-a5b8-2b18f5be6a7b)


## ℹ️ 참고 사항

- 이슈에서 명시한 "나의"보다 "아직"문구가 더 적합한 것 같아 이렇게 수정했습니다.
