### PR TITLE
 [수정-코스 상세, 플랜 상세] 일치하는 id 없을 경우 보여줄 페이지 구현

### DIFF
--- a/src/views/detail-course/index.tsx
+++ b/src/views/detail-course/index.tsx
@@ -9,14 +9,19 @@ import { useGetCourse } from '@/src/entities/course'
 import { useGetComments } from '@/src/entities/comment'
 import defaultImg from '@/src/assets/images/(logo)/logo_default.png'
 import ReviewCommentCard from '@/src/widgets/review-comment-card'
+import { useRouter } from 'next/navigation'
 
 interface DetailCourseProps {
   courseId: string
 }
 
 export default function DetailCourse({ courseId }: DetailCourseProps) {
-  const { data: course } = useGetCourse(courseId)
+  const { data: course, isError } = useGetCourse(courseId)
   const { data: comments } = useGetComments(courseId)
+  const router = useRouter()
+  if (isError) {
+    router.push("/not-found")
+  }
   if (!course) return <div>Loading...</div>
 
   return (

--- a/src/views/detail-plan/index.tsx
+++ b/src/views/detail-plan/index.tsx
@@ -2,14 +2,18 @@
 
 import CoursePlanDetailLayout from '@/src/widgets/course-plan-detail-layout'
 import { useGetPlan } from '@/src/entities/plan'
+import { useRouter } from 'next/navigation'
 
 interface DetailPlanProps {
   planId: string
 }
 
 export default function DetailPlan({ planId }: DetailPlanProps) {
-  const { data: plan } = useGetPlan(planId)
-
+  const { data: plan, isError } = useGetPlan(planId)
+  const router = useRouter()
+  if (isError) {
+    router.push("/not-found")
+  }
   if (!plan) return <div>Loading...</div>
 
   return <CoursePlanDetailLayout type='plan' id={planId} data={plan} />


### PR DESCRIPTION
## 📝 개요

- Custom Hook에서 isError를 반환 받아, 요청에 실패한 경우 /not-found 경로로 redirect 


## 🔗 관련 이슈

  - #118 

## ℹ️ 참고 사항

- BE 예외 처리가 세분화되면 그에 따라 맞출 예정
