### PR TITLE
feat: 인증관련 엔드 포인트 수정

### DIFF
--- a/app/oauth/[provider]/callback/page.tsx
+++ b/app/oauth/[provider]/callback/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import { postLogin } from '@/src/entities/auth'
 import { useRouter } from 'next/navigation'
 
-function LoginHandler() {
+function LoginHandler({ provider }: { provider: string }) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const code = searchParams.get('code')
@@ -14,7 +14,7 @@ function LoginHandler() {
   useEffect(() => {
     const handleLogin = async () => {
       if (code && state) {
-        const isLogin = await postLogin(code,state)
+        const isLogin = await postLogin(code,state,provider)
         if (isLogin.success && !isLogin.onBoarding) {
           router.replace('/')
         } else if (isLogin.onBoarding) {
@@ -31,10 +31,11 @@ function LoginHandler() {
   return null
 }
 
-export default function Page() {
+export default function Page({ params }: { params: { provider: string } }) {
+  console.log(params.provider)
   return (
     <Suspense fallback={<div>Loading...</div>}>
-      <LoginHandler />
+      <LoginHandler provider={params.provider} />
     </Suspense>
   )
 }

--- a/app/oauth/kakao/callback/page.tsx
+++ b/app/oauth/kakao/callback/page.tsx
@@ -9,11 +9,12 @@ function LoginHandler() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const code = searchParams.get('code')
+  const state = searchParams.get('state')
 
   useEffect(() => {
     const handleLogin = async () => {
-      if (code) {
-        const isLogin = await postLogin(code)
+      if (code && state) {
+        const isLogin = await postLogin(code,state)
         if (isLogin.success && !isLogin.onBoarding) {
           router.replace('/')
         } else if (isLogin.onBoarding) {

--- a/src/entities/auth/api/get-login-url.ts
+++ b/src/entities/auth/api/get-login-url.ts
@@ -1,3 +1,4 @@
 export const getLoginUrl = async (): Promise<string> => {
-  return "https://dev.api.wooco.kr/api/v1/oauth2/authorization/kakao"
+  const SERVER_URL = process.env.NEXT_PUBLIC_SERVER_URL
+  return `${SERVER_URL}/api/v1/oauth2/authorization/kakao`
 }

--- a/src/entities/auth/api/get-login-url.ts
+++ b/src/entities/auth/api/get-login-url.ts
@@ -1,7 +1,3 @@
-import { publicAxios } from '@/src/shared/api'
-
 export const getLoginUrl = async (): Promise<string> => {
-  const url = `/auth/kakao/social-login/url`
-  const response = await publicAxios.get(url)
-  return response.data.results.url
+  return "https://dev.api.wooco.kr/api/v1/oauth2/authorization/kakao"
 }

--- a/src/entities/auth/api/post-login.ts
+++ b/src/entities/auth/api/post-login.ts
@@ -2,12 +2,13 @@ import useUserStore from '@/src/shared/store/userStore'
 import { publicAxios, customAxios } from '@/src/shared/api'
 
 export const postLogin = async (
-  code: string | null
+  code: string | null,
+  state: string | null
 ): Promise<{ success: boolean; onBoarding?: boolean; userId?: string }> => {
   try {
-    if (!code) return { success: false }
-    const url = `/auth/kakao/social-login`
-    const body = JSON.stringify({ code })
+    if (!code || !state) return { success: false }
+    const url = `/oauth2/kakao/login`
+    const body = JSON.stringify({ code,state })
 
     const response = await publicAxios.post(url, body)
     const accessToken = response.data.results.access_token

--- a/src/entities/auth/api/post-login.ts
+++ b/src/entities/auth/api/post-login.ts
@@ -3,14 +3,13 @@ import { publicAxios, customAxios } from '@/src/shared/api'
 
 export const postLogin = async (
   code: string | null,
-  state: string | null
+  state: string | null,
+  provider: string | null
 ): Promise<{ success: boolean; onBoarding?: boolean; userId?: string }> => {
   try {
-    if (!code || !state) return { success: false }
-    const url = `/oauth2/kakao/login`
-    const body = JSON.stringify({ code,state })
-
-    const response = await publicAxios.post(url, body)
+    if (!code || !state || !provider) return { success: false }
+    const url = `/oauth2/${provider}/login?code=${code}&state=${state}`
+    const response = await publicAxios.get(url)
     const accessToken = response.data.results.access_token
 
     if (accessToken) {


### PR DESCRIPTION
## 📝 개요

- OAuth 관련 엔드포인트 변경 사항 반영

## ✨ 변경 사항

  - ✨ `/api/v1/oauth2/authorization/kakao`
    - Redirect 목표 origin이 kakao 인증 서버인 관계로, CORS 이슈를 해결하고자 Axios 요청이 아닌 주소 값 String 사용 
  - ✨`/api/v1/oauth2/kakao/login`
    - callback uri로부터 query params "code", "state"를 받아 BE로 전달
  - ✨ 확장성을 고려해 callback uri의 "kakao"에 해당하는 provider 값을 path variable로 지정


## 🔗 관련 이슈

  - closes #209 

## ℹ️ 참고 사항
https://devtalk.kakao.com/t/cors-error/121958/3

