### PR TITLE
[수정] 유저 정보 조회 관련 오류 해결

### DIFF
--- a/src/entities/user/api/get-user-summary.ts
+++ b/src/entities/user/api/get-user-summary.ts
@@ -18,5 +18,6 @@ export const useGetUserSummary = (id: string) => {
   return useQuery({
     queryKey: USER_QUERY_KEY.detail(id),
     queryFn: () => getUserSummary(id),
+    gcTime: 0,
   })
 }


### PR DESCRIPTION
## 📝 개요

- 유저 정보 수정 페이지 접속 시 생긴 오류를 해결했습니다.

## ✨ 변경 사항

  - ✨ 데이터 로딩 중 화면 표시 안하도록 isLoading 설정
  - ✨ 유저 정보 수정 후 뒤로가기 클릭 시에도 정보 조회 api 호출하도록 데이터 캐시 타임(gcTime)을 0으로 설정

## 🔗 관련 이슈

-

## 📸 스크린샷 (옵션)
-

## ℹ️ 참고 사항
-
