### PR TITLE
[기능 및 수정] 장소 상세 페이지의 디자인 반영 및 기능 수정

### DIFF
--- a/firbase.ts
+++ b/firbase.ts
@@ -9,6 +9,6 @@ const firebaseConfig = {
     messagingSenderId: "48093061821",
     appId: "1:48093061821:web:4aac24e5a09e82625b8dd4",
     measurementId: "G-R5NZNL4Z67"
-  };
+  }
 // Initialize Firebase
 export const app = initializeApp(firebaseConfig);

--- a/src/entities/place/api/get-place-reviews.ts
+++ b/src/entities/place/api/get-place-reviews.ts
@@ -20,5 +20,6 @@ export const useGetPlaceReviews = (id: string) => {
   return useQuery({
     queryKey: PLACE_QUERY_KEY.reviews(id),
     queryFn: () => getPlaceReviews(id),
+    gcTime: 0,
   })
 }

--- a/src/features/header-elements/title-with-tag-style.tsx
+++ b/src/features/header-elements/title-with-tag-style.tsx
@@ -1,18 +1,17 @@
-import { BackButton } from '@/src/shared/ui'
-
 export function TitleWithTagStyle({
   title,
-  handleClickBack,
+  isTitleCenter,
 }: {
   title: string
-  handleClickBack: () => void
+  isTitleCenter?: boolean
 }) {
   return (
-    <div className='flex items-center gap-[10px]'>
-      <BackButton onClick={handleClickBack} />
-      <div className='px-[20px] py-[5px] text-[13px] font-bold text-white bg-container-blue rounded-[20px]'>
-        {title}
-      </div>
+    <div
+      className={`px-[20px] py-[5px] text-[13px] font-bold text-white bg-container-blue rounded-[20px] ${
+        isTitleCenter && 'absolute left-1/2 transform -translate-x-1/2'
+      }`}
+    >
+      {title}
     </div>
   )
 }

--- a/src/views/detail-comment/index.tsx
+++ b/src/views/detail-comment/index.tsx
@@ -49,7 +49,6 @@ export default function DetailComment({ courseId }: { courseId: string }) {
               key={comment.id}
               id={comment.id}
               content={comment}
-              isHaveOption={true}
               refetch={refetch}
             />
           )

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -230,6 +230,15 @@ export default function DetailPlace({ id }: { id: string }) {
         </div>
         {contextHolder}
       </div>
+
+      <Spacer height={25} />
+      <footer className='w-full h-[74px] px-[20px] py-[13px] flex flex-col items-start justify-center gap-[5px] text-[#2A2A2A] bg-[#F5F5F5]'>
+        <span className='text-[13px] font-bold'>잘못 제공된 정보 제보!</span>
+        <span className='text-[9px]'>
+          <p>잘못된 정보를 하단 메일로 제보해주시면 소정의 상품을 드립니다.</p>
+          <p>kr.wooco@gmail.com</p>
+        </span>
+      </footer>
     </>
   )
 }

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -153,12 +153,12 @@ export default function DetailPlace({ id }: { id: string }) {
             title='리뷰'
             subtitle='가장 언급 많은 키워드 랭킹이에요!'
             button={
-              <span
+              <button
                 className='text-sub text-gray-400'
                 onClick={() => router.push(`/places/${id}/reviews/new`)}
               >
                 작성하기
-              </span>
+              </button>
             }
           >
             <Spacer height={15} />

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -76,7 +76,12 @@ export default function DetailPlace({ id }: { id: string }) {
 
   return (
     <>
-      <ActionHeader title={placeData.name || ''} isTitleTag isBack />
+      <ActionHeader
+        title={placeData.name || ''}
+        isTitleTag
+        isTitleCenter
+        isBack
+      />
       <div
         className={'w-full flex flex-col items-center min-h-[100vh] bg-white'}
       >

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -151,38 +151,39 @@ export default function DetailPlace({ id }: { id: string }) {
         <div ref={reviewRef} className='w-full flex flex-col items-center'>
           <Section
             title='리뷰'
-            subtitle='가장 언급 많은 키워드 랭킹이에요!'
+            subtitle={
+              placeData.place_one_line_review_stats.length > 0
+                ? '가장 언급 많은 키워드 랭킹이에요!'
+                : ''
+            }
             button={
               <button
-                className='text-sub text-gray-400'
+                className='text-middle text-gray-400'
                 onClick={() => router.push(`/places/${id}/reviews/new`)}
               >
                 작성하기
               </button>
             }
           >
-            <Spacer height={15} />
-            {placeData.review_count !== 0 ? (
-              <ReviewStats
-                placeOnLineReviewStats={placeData.place_one_line_review_stats}
-                AverageRating={placeData.average_rating}
-              />
-            ) : (
-              <div className='h-[100px] flex items-center justify-center'>
-                <span className='text-description text-sub'>
-                  아직 리뷰를 기다리고 있어요!
-                </span>
-              </div>
-            )}
-            <Spacer height={15} />
+            {placeData.review_count !== 0 &&
+              placeData.place_one_line_review_stats.length > 0 && (
+                <>
+                  <Spacer height={15} />
+                  <ReviewStats
+                    placeOnLineReviewStats={
+                      placeData.place_one_line_review_stats
+                    }
+                    AverageRating={placeData.average_rating}
+                  />
+                  <Spacer height={15} />
+                  <Spacer height={4} className='bg-light-gray' />
+                </>
+              )}
           </Section>
 
-          {placeData.review_count !== 0 && (
+          {placeData.review_count !== 0 ? (
             <>
-              <Spacer height={4} className='bg-light-gray' />
-
-              <div className='flex flex-col w-full px-[20px]'>
-                <Spacer height={20} />
+              <div className='flex flex-col w-full px-[20px] py-[20px]'>
                 {reviewData.map((review) => (
                   <ReviewCommentCard
                     key={review.id}
@@ -192,9 +193,13 @@ export default function DetailPlace({ id }: { id: string }) {
                   />
                 ))}
               </div>
-
-              <Spacer height={20} />
             </>
+          ) : (
+            <div className='h-[200px] flex items-center justify-center'>
+              <span className='text-description text-middle'>
+                아직 리뷰를 기다리고 있어요!
+              </span>
+            </div>
           )}
 
           <div className='flex flex-col justify-center items-center gap-[18px]'>

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -144,7 +144,7 @@ export default function DetailPlace({ id }: { id: string }) {
           />
 
           <Spacer height={20} />
-          <Spacer height={8} className='bg-light-gray' />
+          <Spacer height={4} className='bg-light-gray' />
           <Spacer height={20} />
         </div>
 
@@ -179,11 +179,10 @@ export default function DetailPlace({ id }: { id: string }) {
 
           {placeData.review_count !== 0 && (
             <>
-              <Spacer height={20} />
-              <Spacer height={8} className='bg-light-gray' />
+              <Spacer height={4} className='bg-light-gray' />
 
-              <div className='flex flex-col w-full gap-[25px] px-[20px]'>
-                <Spacer height={4} />
+              <div className='flex flex-col w-full px-[20px]'>
+                <Spacer height={20} />
                 {reviewData.map((review) => (
                   <ReviewCommentCard
                     key={review.id}
@@ -192,10 +191,8 @@ export default function DetailPlace({ id }: { id: string }) {
                     refetch={refetch}
                   />
                 ))}
-                <Spacer height={24} />
               </div>
 
-              <Spacer height={8} className='bg-light-gray' />
               <Spacer height={20} />
             </>
           )}

--- a/src/views/list-place-review/index.tsx
+++ b/src/views/list-place-review/index.tsx
@@ -13,13 +13,14 @@ export default function ListPlaceReview({ placeId }: { placeId: string }) {
   return (
     <>
       <ActionHeader title='전체 리뷰' isBack />
-      <div className='flex flex-col'>
+      <div className='flex flex-col px-[20px]'>
+        <Spacer height={20} />
         {reviewData.map((review) => (
           <div key={review.id}>
             <ReviewCommentCard id={placeId} content={review} />
-            <Spacer height={8} className='bg-light-gray' />
           </div>
         ))}
+        <Spacer height={20} />
       </div>
     </>
   )

--- a/src/widgets/default-footer/index.tsx
+++ b/src/widgets/default-footer/index.tsx
@@ -23,8 +23,6 @@ export default function DefaultFooter() {
   const isComment = path?.includes('/comments')
   const isUserSetting = path?.includes('/setting')
   const isNotice = path?.includes('/notices')
-  const isPlace = path?.includes('/places')
-  const isReview = path?.includes('/reviews')
   const isNotification = path?.includes('/notifications')
   const isWelcome = path?.includes('welcome')
   const isOnBoard = path?.includes('onboard')
@@ -53,61 +51,57 @@ export default function DefaultFooter() {
     return null
 
   return (
-    (!isPlace || isReview) && (
-      <footer className='fixed bottom-0 z-1000 shadow-custom max-w-[375px] text-black text-base bg-white flex w-full h-[60px] justify-around items-center'>
-        <Link href='/' className='flex flex-col items-center'>
-          <Home
-            size={25}
-            strokeWidth={1.5}
-            stroke={`${isHome ? '#5A59F2' : '#000000'}`}
-          />
-          <span
-            className={`text-[10px] leading-[17px] ${isHome && 'text-brand'}`}
-          >
-            홈
-          </span>
-        </Link>
-        <Link href='/courses' className='flex flex-col items-center'>
-          <Image
-            src={isCourse ? coursePurple : course}
-            width={25}
-            height={25}
-            alt='코스'
-          />
-          <span
-            className={`text-[10px] leading-[17px] ${isCourse && 'text-brand'}`}
-          >
-            코스
-          </span>
-        </Link>
-        <Link href='/plans' className='flex flex-col items-center'>
-          <SquareChartGantt
-            size={25}
-            strokeWidth={1.5}
-            stroke={`${isPlan ? '#5A59F2' : '#000000'}`}
-          />
-          <span
-            className={`text-[10px] leading-[17px] ${isPlan && 'text-brand'}`}
-          >
-            플랜
-          </span>
-        </Link>
-        <button
-          onClick={handleClickMyPage}
-          className='flex flex-col items-center'
+    <footer className='fixed bottom-0 z-1000 shadow-custom max-w-[375px] text-black text-base bg-white flex w-full h-[60px] justify-around items-center'>
+      <Link href='/' className='flex flex-col items-center'>
+        <Home
+          size={25}
+          strokeWidth={1.5}
+          stroke={`${isHome ? '#5A59F2' : '#000000'}`}
+        />
+        <span
+          className={`text-[10px] leading-[17px] ${isHome && 'text-brand'}`}
         >
-          <UserRound
-            strokeWidth={1.5}
-            size={25}
-            stroke={`${isMy ? '#5A59F2' : '#000000'}`}
-          />
-          <span
-            className={`text-[10px] leading-[17px] ${isMy && 'text-brand'}`}
-          >
-            마이
-          </span>
-        </button>
-      </footer>
-    )
+          홈
+        </span>
+      </Link>
+      <Link href='/courses' className='flex flex-col items-center'>
+        <Image
+          src={isCourse ? coursePurple : course}
+          width={25}
+          height={25}
+          alt='코스'
+        />
+        <span
+          className={`text-[10px] leading-[17px] ${isCourse && 'text-brand'}`}
+        >
+          코스
+        </span>
+      </Link>
+      <Link href='/plans' className='flex flex-col items-center'>
+        <SquareChartGantt
+          size={25}
+          strokeWidth={1.5}
+          stroke={`${isPlan ? '#5A59F2' : '#000000'}`}
+        />
+        <span
+          className={`text-[10px] leading-[17px] ${isPlan && 'text-brand'}`}
+        >
+          플랜
+        </span>
+      </Link>
+      <button
+        onClick={handleClickMyPage}
+        className='flex flex-col items-center'
+      >
+        <UserRound
+          strokeWidth={1.5}
+          size={25}
+          stroke={`${isMy ? '#5A59F2' : '#000000'}`}
+        />
+        <span className={`text-[10px] leading-[17px] ${isMy && 'text-brand'}`}>
+          마이
+        </span>
+      </button>
+    </footer>
   )
 }

--- a/src/widgets/header/action-header.tsx
+++ b/src/widgets/header/action-header.tsx
@@ -19,6 +19,7 @@ interface ActionHeaderProps {
   title: string
   isBack?: boolean
   isTitleTag?: boolean
+  isTitleCenter?: boolean
   isOnBoarding?: boolean
   isBlue?: boolean
   close?: () => void
@@ -33,6 +34,7 @@ export function ActionHeader({
   title,
   isBack,
   isTitleTag,
+  isTitleCenter,
   isListView,
   setIsListView,
   isOnBoarding,
@@ -91,8 +93,13 @@ export function ActionHeader({
   return (
     <HeaderBase className='px-[10px] border-b-[1px] border-container-blue'>
       {isTitleTag ? (
-        <div className='flex items-center gap-[10px]'>
-          <TitleWithTagStyle title={title} handleClickBack={handleClickBack} />
+        <div
+          className={`flex items-center ${
+            isTitleCenter ? 'w-full relative' : 'gap-[10px]'
+          }`}
+        >
+          <BackButton onClick={handleClickBack} />
+          <TitleWithTagStyle title={title} isTitleCenter={!!isTitleCenter} />
           {showLike && (
             <Heart
               onClick={() => setIsLiked && setIsLiked(!isLiked)}

--- a/src/widgets/review-comment-card/index.tsx
+++ b/src/widgets/review-comment-card/index.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { formatDateToYYYYMMDD, passFromCreate } from '@/src/shared/utils/date'
 import useUserStore from '@/src/shared/store/userStore'
 import { PlaceReviewDetailType } from '@/src/entities/place'
-import { ProfileImage, Spacer, OptionDropbox } from '@/src/shared/ui'
+import { ProfileImage, OptionDropbox } from '@/src/shared/ui'
 import { ReviewTag, StarRateView } from '@/src/features'
 import { useEffect, useRef, useState } from 'react'
 import { useDeletePlaceReview } from '@/src/entities/place'
@@ -14,19 +14,18 @@ import {
   useDeleteComment,
 } from '@/src/entities/comment'
 import { useForm } from 'react-hook-form'
-import { Send, X } from 'lucide-react'
+import { Send } from 'lucide-react'
+import Image from 'next/image'
 
 type ReviewCommentCardProps = {
   id: string
   content: PlaceReviewDetailType | CommentType
-  isHaveOption?: boolean
   refetch?: () => void
 }
 
 export default function ReviewCommentCard({
   id,
   content,
-  isHaveOption,
   refetch,
 }: ReviewCommentCardProps) {
   const { user } = useUserStore()
@@ -119,7 +118,7 @@ export default function ReviewCommentCard({
   }, [isOpen])
 
   return (
-    <div className='w-full flex items-end flex-col'>
+    <div className='w-full flex items-end flex-col gap-[10px]'>
       <div className='w-full justify-between flex items-center'>
         <Link
           href={`/users/${content.writer.id}`}
@@ -143,39 +142,30 @@ export default function ReviewCommentCard({
           </div>
         </Link>
 
-        {isHaveOption &&
-          isMine &&
-          (isEditingComment ? (
-            <X
-              size={20}
-              className='cursor-pointer text-black'
-              strokeWidth={1.5}
-              onClick={() => setIsEditingComment(false)}
-            />
-          ) : (
-            <OptionDropbox
-              isMine={isMine}
-              isOpen={isOpen}
-              setIsOpen={setIsOpen}
-              onToggle={() => setIsOpen(!isOpen)}
-              ref={menuRef}
-              type={isPlaceReview ? 'review' : 'comment'}
-              id={content.id.toString()}
-              handleDelete={handleDelete}
-              {...(isPlaceReview
-                ? { placeId: id && id.toString() }
-                : {
-                    isComment: true,
-                    setIsEditingComment: setIsEditingComment,
-                  })}
-            />
-          ))}
+        {isMine && (
+          <OptionDropbox
+            isMine={isMine}
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            onToggle={() => setIsOpen(!isOpen)}
+            ref={menuRef}
+            type={isPlaceReview ? 'review' : 'comment'}
+            id={content.id.toString()}
+            handleDelete={handleDelete}
+            {...(isPlaceReview
+              ? { placeId: id && id.toString() }
+              : {
+                  isComment: true,
+                  setIsEditingComment: setIsEditingComment,
+                })}
+          />
+        )}
       </div>
 
-      <Spacer height={21} />
       {isPlaceReview && (
         <>
-          <section className='w-full flex flex-col items-start gap-[10px] px-[12px]'>
+          <section className='w-full flex flex-col items-start gap-[5px]'>
+            <StarRateView rate={content.rating} size={15} />
             {content.one_line_reviews.length > 0 && (
               <div className='flex flex-row items-center gap-[5px]'>
                 {content.one_line_reviews.map((tag, index) => (
@@ -183,9 +173,7 @@ export default function ReviewCommentCard({
                 ))}
               </div>
             )}
-            <StarRateView rate={content.rating} size={10} />
           </section>
-          <Spacer height={10} />
         </>
       )}
 
@@ -210,7 +198,23 @@ export default function ReviewCommentCard({
           </button>
         </form>
       ) : (
-        <span className='w-full text-sub px-[12px]'>{content.contents}</span>
+        <span className='w-full text-sub'>{content.contents}</span>
+      )}
+
+      {isPlaceReview && (
+        <div className='h-full w-full overflow-x-auto flex flex-1 items-center justify-start gap-[5px] scrollbar-hide pr-[10px]'>
+          {content.image_urls.map((image, index) => (
+            <Image
+              key={index}
+              alt='place'
+              width={74}
+              height={74}
+              src={image}
+              className='w-[74px] h-[74px] rounded-[5px] object-cover'
+              layout='fixed'
+            />
+          ))}
+        </div>
       )}
     </div>
   )

--- a/src/widgets/review-comment-card/index.tsx
+++ b/src/widgets/review-comment-card/index.tsx
@@ -118,7 +118,7 @@ export default function ReviewCommentCard({
   }, [isOpen])
 
   return (
-    <div className='w-full flex items-end flex-col gap-[10px]'>
+    <div className='w-full flex items-end flex-col gap-[10px] py-[5px]'>
       <div className='w-full justify-between flex items-center'>
         <Link
           href={`/users/${content.writer.id}`}


### PR DESCRIPTION
## 📝 개요

- 장소 상세 페이지 관련 기능 추가 및 코드 수정을 위한 PR입니다.

## ✨ 변경 사항

  - ✨ 장소 상세 페이지의 제목 위치 수정
  - ✨ 장소 리뷰 카드 디자인 반영
  - ✨ 작성하기 버튼의 태그를 button으로 수정
  - ✨ 장소 상세 페이지의 레이아웃 전반적으로 수정
  - ✨ 리뷰 태그 정보 없을 경우 그래프 나타나지 않도록 설정
  - ✨ 리뷰 조회 API의 gcTime을 0으로 설정하여, 리뷰 작성 후 뒤로가기 시에도 정상적으로 조회되도록 수정
  - ✨ 잘못된 정보 제보를 위한 푸터 추가
  - ✨ 장소 페이지에도 푸터 표시되도록 설정 (디자인 반영)

## 🔗 관련 이슈

- closes #234 , #235 , #236 

## 📸 스크린샷 (옵션)

|항목|원본|수정된 버전|
|---|---|---|
|리뷰 카드|![](https://github.com/user-attachments/assets/27c1e7f8-49d6-45e2-ae5b-ecf23213e3c2)|![](https://github.com/user-attachments/assets/df33d9b9-a9a6-4831-b03c-e4b86f8352a5)|
|그래프|![](https://github.com/user-attachments/assets/4b6411f0-f4df-4966-ba58-3df2b6458799)|![](https://github.com/user-attachments/assets/63ff0a8e-d118-49bc-9e30-cec80a0e6eeb)|
|전체 페이지|![](https://github.com/user-attachments/assets/4a722f4c-4284-4500-9722-fcc3a824f9af)|![](https://github.com/user-attachments/assets/df7d4513-d1cf-4fe7-9fce-216f8e000a31)|



## ℹ️ 참고 사항

- 잘못 제공된 정보 제보 푸터에 사용된 색상들은 나중에 색상 팔레트 설정하면 변경하기 쉽게 하기 위해 우선 hex로 설정해두었습니다.
- 이제부터라도 커밋 로그 통일하면 좋을 것 같아서 저도 영어로 작성했습니다~!