### PR TITLE
[플랜 공유] 플랜을 코스로 변환하는 과정에서 미래 날짜 데이터가 그대로 넘어오는 현상 수정

### DIFF
--- a/src/entities/course/api/get-course.ts
+++ b/src/entities/course/api/get-course.ts
@@ -14,9 +14,13 @@ export const getCourse = async (id: string): Promise<CourseType> => {
   }
 }
 
-export const useGetCourse = (id: string) => {
+export const useGetCourse = (
+  id: string,
+  enabled: boolean = true
+) => {
   return useQuery({
     queryKey: COURSE_QUERY_KEY.detail(id),
     queryFn: () => getCourse(id),
+    enabled
   })
 }

--- a/src/entities/plan/api/get-plan.ts
+++ b/src/entities/plan/api/get-plan.ts
@@ -13,9 +13,13 @@ export const getPlan = async (id: string) => {
   }
 }
 
-export const useGetPlan = (id: string) => {
+export const useGetPlan = (
+  id: string,
+  enabled: boolean = true
+) => {
   return useQuery({
     queryKey: PLAN_QUERY_KEY.detail(id),
     queryFn: () => getPlan(id),
+    enabled
   })
 }

--- a/src/widgets/course-plan-detail-layout/detail-layout.tsx
+++ b/src/widgets/course-plan-detail-layout/detail-layout.tsx
@@ -69,12 +69,13 @@ export function CoursePlanDetailLayout({
   const handleClickShareCourse = () => {
     setIsClicked(!isClicked)
 
-    const { primary_region, secondary_region, places, visit_date } = data
+    const { primary_region, secondary_region, places,title,contents } = data
     const filteredData = {
+      title,
+      contents,
       primary_region,
       secondary_region,
       places,
-      visit_date,
     }
 
     sessionStorage.setItem('course', JSON.stringify(filteredData))

--- a/src/widgets/course-plan-detail-layout/detail-layout.tsx
+++ b/src/widgets/course-plan-detail-layout/detail-layout.tsx
@@ -69,10 +69,8 @@ export function CoursePlanDetailLayout({
   const handleClickShareCourse = () => {
     setIsClicked(!isClicked)
 
-    const { primary_region, secondary_region, places,title,contents } = data
+    const { primary_region, secondary_region, places} = data
     const filteredData = {
-      title,
-      contents,
       primary_region,
       secondary_region,
       places,

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -24,6 +24,7 @@ import {
   useUpdateCourse,
 } from '@/src/entities/course'
 import { useQueryClient } from '@tanstack/react-query'
+import useRegionStore from '@/src/shared/store/regionStore'
 
 const LAYOUT_TYPE = {
   course: 'course' as const,
@@ -145,14 +146,16 @@ export default function CoursePlanFormLayout({
     ) {
       storedData = sessionStorage.getItem('plan')
     }
-    console.log(storedData)
 
     if (storedData) {
       const sharedData = JSON.parse(storedData)
+      setValue('title',sharedData.title)
+      setValue('contents',sharedData.contents)
       setValue('primary_region', sharedData.primary_region)
       setValue('secondary_region', sharedData.secondary_region)
-      setValue('visit_date', sharedData.visit_date)
+      setValue('visit_date', sharedData?.visit_date ? sharedData.visit_date : "")
       setPlaces(sharedData.places || [])
+      useRegionStore.setState({ currentRegion: [sharedData.primary_region,sharedData.secondary_region] })
       setIsDataLoaded(true)
     }
 

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -89,9 +89,8 @@ export default function CoursePlanFormLayout({
       visit_date: '',
     },
   })
-
-  const { data: courseData } = useGetCourse(id || '')
-  const { data: planData } = useGetPlan(id || '')
+  const { data: courseData } = useGetCourse(id || '', type == 'course' && !!id)
+  const { data: planData } = useGetPlan(id || '',type == 'plan' && !!id)
   const fetchData = useMemo(() => {
     return type === LAYOUT_TYPE.course
       ? courseData


### PR DESCRIPTION
## 📝 개요

- #241  버그 픽스

## ✨ 변경 사항
  - ✨ 더 이상 플랜을 코스로 만들 때, 날짜 정보가 넘어가지 않습니다.
  - ✨ 이제 플랜을 코스로 만들 때, 제목과 설명이 자동으로 이전됩니다.
  - ✨ 플랜과 코스에서 공통으로 사용하는 컴포넌트에서 불필요한 네트워크 요청이 발생하던 현상을 수정했습니다.

## 🔗 관련 이슈
  - closes #241 

## 📸 스크린샷 (옵션)

![Animation4](https://github.com/user-attachments/assets/d6c20d4b-37b1-4ab4-afb1-f6c9e66b97d1)

