### PR TITLE
[리팩토링] TitleWithTagStyle 컴포넌트 리팩토링

### DIFF
--- a/src/features/header-elements/title-with-tag-style.tsx
+++ b/src/features/header-elements/title-with-tag-style.tsx
@@ -5,9 +5,17 @@ export function TitleWithTagStyle({
   title: string
   isTitleCenter?: boolean
 }) {
-  return (
+  if (!title) return null
+
+  return title.length > 0 ? (
     <div
-      className={`px-[20px] py-[5px] text-[13px] font-bold text-white bg-container-blue rounded-[20px] ${
+      className={`font-semibold w-[100px] h-[35.5px] rounded-[20px] bg-container-blue leading-normal ${
+        isTitleCenter && 'absolute left-1/2 transform -translate-x-1/2'
+      }`}
+    />
+  ) : (
+    <div
+      className={`px-[20px] py-[8px] text-[13px] font-bold text-white bg-container-blue rounded-[20px] font-semibold leading-normal ${
         isTitleCenter && 'absolute left-1/2 transform -translate-x-1/2'
       }`}
     >

--- a/src/widgets/header/course-plan-header.tsx
+++ b/src/widgets/header/course-plan-header.tsx
@@ -14,7 +14,7 @@ import {
   usePostCourseLike,
 } from '@/src/entities/course'
 import { USER_QUERY_KEY } from '@/src/entities/user/api'
-import { HeaderBase } from '@/src/features'
+import { HeaderBase, TitleWithTagStyle } from '@/src/features'
 
 interface CoursePlanHeaderProps {
   title: string
@@ -99,13 +99,8 @@ export function CoursePlanHeader({
       <div className='flex items-center gap-[10px]'>
         <BackButton onClick={handleClickBack} />
       </div>
-      {title.length < 1 ? (
-        <p className='font-semibold w-[100px] h-[30px] px-[20px] py-[8px] rounded-[20px] bg-container-blue leading-normal' />
-      ) : (
-        <p className='font-semibold text-[13px] text-white px-[20px] py-[8px] rounded-[20px] bg-container-blue leading-normal'>
-          {title}
-        </p>
-      )}
+
+      <TitleWithTagStyle title={title} isTitleCenter />
 
       <div className='flex items-center gap-[10px]'>
         {showLike && !isMine && (


### PR DESCRIPTION
## 📝 개요

- 코스 상세, 플랜 상세, 장소 상세 페이지에 사용되는 TitleWithTagStyle 컴포넌트를 리팩토링했습니다.
- 스켈레톤 공통 처리 목적

## ✨ 변경 사항

  - ✨ title 길이 삼항연산 위치 이동

## 🔗 관련 이슈

-

## 📸 스크린샷 (옵션)
-

## ℹ️ 참고 사항
-
