### PR TITLE
[기능] 플랜을 코스로 공유하는 모달 추가 및 토스트 메세지용 컨텍스트 생성

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import localFont from 'next/font/local'
 import { AnimatePresence } from 'framer-motion'
 import { ConfigProvider } from 'antd'
 import ReactQueryProvider from '@/src/shared/provider/ReactQueryProvider'
+import { MessageProvider } from '@/src/shared/lib'
 
 export const metadata: Metadata = {
   title: 'WOOCO - 우코',
@@ -48,10 +49,12 @@ export default function RootLayout({
           <MainHeader />
           <ConfigProvider theme={theme}>
             <AnimatePresence>
-              <div className='mx-auto flex-1 text-black h-full w-full max-w-[375px]'>
-                {children}
-                <Spacer height={60} notShowURLs={['/login']} />
-              </div>
+              <MessageProvider>
+                <div className='mx-auto flex-1 text-black h-full w-full max-w-[375px]'>
+                  {children}
+                  <Spacer height={60} notShowURLs={['/login']} />
+                </div>
+              </MessageProvider>
             </AnimatePresence>
           </ConfigProvider>
           <DefaultFooter />

--- a/src/features/course-card/grid-card/grid-card.tsx
+++ b/src/features/course-card/grid-card/grid-card.tsx
@@ -7,7 +7,7 @@ import { CourseType } from '@/src/entities/course'
 import logo from '@/src/assets/images/(logo)/logo.png'
 import { CourseActionBar, useCourseLike } from '@/src/features'
 import { useEffect, useState } from 'react'
-import { CourseModal } from '@/src/features'
+import { ShareModal } from '@/src/features'
 
 export function CourseGridCard({ course }: { course: CourseType }) {
   const {
@@ -83,10 +83,11 @@ export function CourseGridCard({ course }: { course: CourseType }) {
         setIsModalOpen={setIsModalOpen}
       />
 
-      <CourseModal
+      <ShareModal
+        type='course'
         isOpen={isModalOpen}
         setIsOpen={setIsModalOpen}
-        course={course}
+        data={course}
       />
     </div>
   )

--- a/src/features/course-card/list-card/list-card.tsx
+++ b/src/features/course-card/list-card/list-card.tsx
@@ -4,7 +4,7 @@ import { ImageWithIndex, ProfileImage } from '@/src/shared/ui'
 import { type CourseType } from '@/src/entities/course'
 import Link from 'next/link'
 import { CourseActionBar, useCourseLike } from '@/src/features'
-import { CourseModal } from '../../modal/course-modal'
+import { ShareModal } from '../../modal/share-modal'
 import { useEffect, useState } from 'react'
 
 export function CourseListCard({ course }: { course: CourseType }) {
@@ -90,10 +90,11 @@ export function CourseListCard({ course }: { course: CourseType }) {
         />
       </section>
 
-      <CourseModal
+      <ShareModal
+        type='course'
         isOpen={isModalOpen}
         setIsOpen={setIsModalOpen}
-        course={course}
+        data={course}
       />
     </div>
   )

--- a/src/features/modal/index.ts
+++ b/src/features/modal/index.ts
@@ -1,1 +1,1 @@
-export * from './course-modal'
+export * from './share-modal'

--- a/src/features/place-collapse/place-collapse.tsx
+++ b/src/features/place-collapse/place-collapse.tsx
@@ -5,9 +5,9 @@ import logoDefaultCopy from '@/src/assets/images/(logo)/temp_empty.png'
 import kakaoReview from '@/src/assets/images/kakao_review_icon.svg'
 import allReview from '@/src/assets/images/all_review_icon.svg'
 import type { CoursePlanPlaceType } from '@/src/entities/place'
-import { message } from 'antd'
 import { Spacer } from '@/src/shared/ui'
 import { StarRateView } from '@/src/features'
+import { useMessageApi } from '@/src/shared/lib'
 
 export function PlaceCollapse({
   places,
@@ -18,12 +18,10 @@ export function PlaceCollapse({
   activeIndex: number | null
   setActiveIndex: (key: (prevKey: number | null) => null | number) => void
 }) {
-  const [messageApi, contextHolder] = message.useMessage()
-
+  const messageApi = useMessageApi()
   const toast = (address: string) => {
     navigator.clipboard.writeText(address).then(() => {
-      messageApi.open({
-        type: 'success',
+      messageApi.success({
         content: '주소가 클립보드에 복사되었습니다.',
         duration: 1,
       })
@@ -108,13 +106,14 @@ export function PlaceCollapse({
           </div>
         </div>
         <Spacer height={25} />
-        {contextHolder}
       </div>
     ),
   }))
+
   const toggleItem = (key: number) => {
     setActiveIndex((prevKey) => (prevKey === key ? null : key))
   }
+
   return (
     <div className='w-full px-[30px]'>
       {items.map((item, index) => {

--- a/src/features/place/form-review.tsx
+++ b/src/features/place/form-review.tsx
@@ -3,9 +3,9 @@ import React, { useState, useRef, useEffect } from 'react'
 import { FieldErrors, UseFormRegister, UseFormSetValue } from 'react-hook-form'
 import { ReviewPayloadType } from '@/src/entities/place'
 import { postImage } from '@/src/shared/api'
-import { message } from 'antd'
 import { Spacer } from '@/src/shared/ui'
 import { StarRateForm } from '@/src/features'
+import { useMessageApi } from '@/src/shared/lib'
 
 // 리뷰
 interface ReviewTextareaProps {
@@ -119,7 +119,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
 }) => {
   const fileInput = useRef<HTMLInputElement | null>(null)
   const scrollRef = useRef<HTMLDivElement | null>(null)
-  const [messageApi, contextHolder] = message.useMessage()
+  const messageApi = useMessageApi()
 
   // Drag and Touch Scrolling
   let isDragging = false
@@ -247,7 +247,6 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
           ))}
         </div>
       </div>
-      {contextHolder}
     </div>
   )
 }
@@ -274,7 +273,7 @@ const FormReview: React.FC<FormReviewProps> = ({
   formValues,
 }) => {
   // toast
-  const [messageApi, contextHolder] = message.useMessage()
+  const messageApi = useMessageApi()
   const toast = (type: 'success' | 'error', content: string) => {
     messageApi.open({
       type,
@@ -340,7 +339,6 @@ const FormReview: React.FC<FormReviewProps> = ({
           setValue={setValue}
         />
       </div>
-      {contextHolder}
     </div>
   )
 }

--- a/src/shared/lib/MessageProvider.tsx
+++ b/src/shared/lib/MessageProvider.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import { message } from 'antd'
+
+const MessageApiContext = createContext<
+  ReturnType<typeof message.useMessage>[0] | null
+>(null)
+
+export function MessageProvider({ children }: { children: React.ReactNode }) {
+  const [messageApi, contextHolder] = message.useMessage()
+
+  return (
+    <MessageApiContext.Provider value={messageApi}>
+      {contextHolder}
+      {children}
+    </MessageApiContext.Provider>
+  )
+}
+
+export function useMessageApi() {
+  const context = useContext(MessageApiContext)
+  if (!context) {
+    throw new Error('useMessageApi는 MessageProvider 안에서만 사용 가능합니다.')
+  }
+  return context
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './MessageProvider'

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -4,11 +4,10 @@ import React, { useCallback, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Copy, Phone } from 'lucide-react'
-import { message } from 'antd'
 import { useGetPlace, useGetPlaceReviews } from '@/src/entities/place'
 import { ActionHeader } from '@/src/widgets'
 import { Spacer, KakaoMap } from '@/src/shared/ui'
+import { Copy, Phone } from 'lucide-react'
 import {
   ReviewStats,
   PlaceReviewCard,
@@ -19,6 +18,7 @@ import { Section } from './section'
 import logo from '@/src/assets/images/(logo)/logo.png'
 import allReview from '@/src/assets/images/all_review_icon.svg'
 import kakaoReview from '@/src/assets/images/kakao_review_icon.svg'
+import { useMessageApi } from '@/src/shared/lib'
 import { SkeletonDetailPlaceLayout } from './skeleton-layout'
 
 export default function DetailPlace({ id }: { id: string }) {
@@ -26,17 +26,16 @@ export default function DetailPlace({ id }: { id: string }) {
   const { data: reviewData, refetch } = useGetPlaceReviews(id)
 
   const router = useRouter()
+  const messageApi = useMessageApi()
 
   const [activeTab, setActiveTab] = useState<ScrollTabType>('info')
   const infoRef = useRef<HTMLDivElement>(null)
   const reviewRef = useRef<HTMLDivElement>(null)
   const isScrollingRef = useRef<boolean>(false)
 
-  const [messageApi, contextHolder] = message.useMessage()
   const toast = (address: string) => {
     navigator.clipboard.writeText(address).then(() => {
-      messageApi.open({
-        type: 'success',
+      messageApi.success({
         content: '주소가 클립보드에 복사되었습니다.',
         duration: 1,
       })
@@ -235,7 +234,6 @@ export default function DetailPlace({ id }: { id: string }) {
             </Link>
           </div>
         </div>
-        {contextHolder}
       </div>
 
       <Spacer height={25} />

--- a/src/views/detail-plan/index.tsx
+++ b/src/views/detail-plan/index.tsx
@@ -26,12 +26,11 @@ export default function DetailPlan({ planId }: DetailPlanProps) {
     }
   }, [isLoading])
 
-  if (isError) {
+  if (isLoading) return <SkeletonCoursePlanDetailLayout type='course' />
+
+  if (isError || !plan) {
     router.push('/not-found')
   }
-
-  if (isLoading || !plan)
-    return <SkeletonCoursePlanDetailLayout type='course' />
 
   return <CoursePlanDetailLayout type='plan' id={planId} data={plan} />
 }

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -3,7 +3,6 @@
 import { useForm } from 'react-hook-form'
 import { useRouter } from 'next/navigation'
 import { useState, useEffect, useMemo } from 'react'
-import { message } from 'antd'
 import { Spacer } from '@/src/shared/ui'
 import SearchPlace from '@/src/views/search-place'
 import { ActionHeader } from '@/src/widgets'
@@ -25,6 +24,7 @@ import {
 } from '@/src/entities/course'
 import { useQueryClient } from '@tanstack/react-query'
 import useRegionStore from '@/src/shared/store/regionStore'
+import { useMessageApi } from '@/src/shared/lib'
 
 const LAYOUT_TYPE = {
   course: 'course' as const,
@@ -62,9 +62,10 @@ export default function CoursePlanFormLayout({
 }: CoursePlanFormLayoutProps) {
   const router = useRouter()
   const queryClient = useQueryClient()
+  const messageApi = useMessageApi()
+
   const [places, setPlaces] = useState<CoursePlanPlaceType[]>([])
   const [openSearchPlace, setOpenSearchPlace] = useState<boolean>(false)
-  const [messageApi, contextHolder] = message.useMessage()
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
   const [isDataLoaded, setIsDataLoaded] = useState<boolean>(false)
 
@@ -90,7 +91,7 @@ export default function CoursePlanFormLayout({
     },
   })
   const { data: courseData } = useGetCourse(id || '', type == 'course' && !!id)
-  const { data: planData } = useGetPlan(id || '',type == 'plan' && !!id)
+  const { data: planData } = useGetPlan(id || '', type == 'plan' && !!id)
   const fetchData = useMemo(() => {
     return type === LAYOUT_TYPE.course
       ? courseData
@@ -148,13 +149,18 @@ export default function CoursePlanFormLayout({
 
     if (storedData) {
       const sharedData = JSON.parse(storedData)
-      setValue('title',sharedData.title)
-      setValue('contents',sharedData.contents)
+      setValue('title', sharedData.title)
+      setValue('contents', sharedData.contents)
       setValue('primary_region', sharedData.primary_region)
       setValue('secondary_region', sharedData.secondary_region)
-      setValue('visit_date', sharedData?.visit_date ? sharedData.visit_date : "")
+      setValue(
+        'visit_date',
+        sharedData?.visit_date ? sharedData.visit_date : ''
+      )
       setPlaces(sharedData.places || [])
-      useRegionStore.setState({ currentRegion: [sharedData.primary_region,sharedData.secondary_region] })
+      useRegionStore.setState({
+        currentRegion: [sharedData.primary_region, sharedData.secondary_region],
+      })
       setIsDataLoaded(true)
     }
 
@@ -302,7 +308,6 @@ export default function CoursePlanFormLayout({
           setPlaces={setPlaces}
         />
       )}
-      {contextHolder}
     </div>
   )
 }


### PR DESCRIPTION
## 📝 개요

- 플랜을 코스로 공유하기 위한 모달 추가
- 토스트 메세지용 컨텍스트를 설정하기 위한 Provider 컴포넌트 생성

## ✨ 변경 사항

  - ✨ MessageProvider 컴포넌트 생성
      - `contextHolder`는 Provider 컴포넌트 내부에서 렌더링하고, `messageApi`는 Context로 공유하여, 모든 컴포넌트에서 토스트 메시지를 사용할 수 있도록 구조를 개선했습니다.
  - ✨ CourseModal -> ShareModal 변경하여 모달 재사용
  - ✨ 플랜 상세 조회 페이지의 얼리 리턴 순서 변경 
     - isLoading을 가장 먼저 처리하도록, `!plan` 조건은 isError와 동일하게 처리하도록 수정

## 🔗 관련 이슈

- closes #173 

## 📸 스크린샷 (옵션)

https://github.com/user-attachments/assets/763b5a9f-8609-4152-bb8d-78d9ab247445



## ℹ️ 참고 사항

- 
