### PR TITLE
[수정-마이페이지] 탭 고정 위치 수정

### DIFF
--- a/src/features/course-card/action-bar/ui/course-action-bar.tsx
+++ b/src/features/course-card/action-bar/ui/course-action-bar.tsx
@@ -1,7 +1,11 @@
 'use client'
 
-import { Heart, MessageCircle, Share2 } from 'lucide-react'
+import { MessageCircle, Share2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import Image from 'next/image'
+import heart_fill from '@/src/assets/icon/heart_fullfill_20.svg'
+import heart_empty from '@/src/assets/icon/heart_empty_20.svg'
+import React from 'react'
 
 type Props = {
   courseId: string
@@ -40,12 +44,14 @@ export function CourseActionBar({
           className='flex items-center gap-[4px] cursor-pointer'
           onClick={onToggleLike}
         >
-          <Heart
-            size={iconSize}
-            className='text-brand'
-            fill={isLiked ? '#5A59F2' : 'none'}
-            strokeWidth={1.5}
+          <Image
+            src={isLiked ? (heart_fill as string) : (heart_empty as string)}
+            alt='heart'
+            className='cursor-pointer'
+            width={iconSize}
+            height={iconSize}
           />
+          {/*TODO likeCount is inline, flex padding will be changed with likeCount changing */}
           <span>{likeCount}</span>
         </div>
         <div

--- a/src/features/header-elements/title-with-tag-style.tsx
+++ b/src/features/header-elements/title-with-tag-style.tsx
@@ -15,7 +15,7 @@ export function TitleWithTagStyle({
     />
   ) : (
     <div
-      className={`px-[20px] py-[8px] text-main01 text-white bg-container-blue  max-w-[60%]  truncate rounded-[2025px]  ${
+      className={`px-[20px] py-[8px] text-main01 text-white bg-container-blue max-w-[90%] truncate rounded-[2025px] ${
         isTitleCenter && 'absolute left-1/2 transform -translate-x-1/2'
       }`}
       title={title}

--- a/src/features/header-elements/title-with-tag-style.tsx
+++ b/src/features/header-elements/title-with-tag-style.tsx
@@ -9,15 +9,16 @@ export function TitleWithTagStyle({
 
   return title.length === 0 ? (
     <div
-      className={`font-semibold w-[100px] h-[35.5px] rounded-[20px] bg-container-blue leading-normal ${
+      className={` text-main01 font-semibold w-[100px] h-[35.5px] rounded-[20px] bg-container-blue leading-normal ${
         isTitleCenter && 'absolute left-1/2 transform -translate-x-1/2'
       }`}
     />
   ) : (
     <div
-      className={`px-[20px] py-[8px] text-[13px] font-bold text-white bg-container-blue rounded-[20px] font-semibold leading-normal ${
+      className={`px-[20px] py-[8px] text-main01 text-white bg-container-blue  max-w-[60%]  truncate rounded-[2025px]  ${
         isTitleCenter && 'absolute left-1/2 transform -translate-x-1/2'
       }`}
+      title={title}
     >
       {title}
     </div>

--- a/src/features/user/user-profile-section.tsx
+++ b/src/features/user/user-profile-section.tsx
@@ -1,8 +1,10 @@
 import type { UserSummaryType } from '@/src/entities/user'
 import { ProfileImage } from '@/src/shared/ui'
 import logo from '@/src/assets/images/(logo)/logo.png'
-import { Heart, ChevronRight } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
+import Image from 'next/image'
+import Heart from '@/src/assets/icon/heart_fullfill_20.svg'
 
 export function UserProfileSection({ user }: { user: UserSummaryType }) {
   const { user_id, profile_url, name, description, like_course_count } = user
@@ -25,7 +27,7 @@ export function UserProfileSection({ user }: { user: UserSummaryType }) {
         <p className='text-middle font-medium'>관심 코스 목록</p>
         <div className='flex flex-row justify-center items-center gap-[6px]'>
           <div className='flex flex-row gap-[4px]'>
-            <Heart className='fill-brand stroke-0 mt-[1.5px]' size={20} />
+            <Image src={Heart as string} alt='heart' width={20} height={20} />
             {like_course_count}
           </div>
           <ChevronRight className='text-description' size={24} />

--- a/src/features/user/user-profile-section.tsx
+++ b/src/features/user/user-profile-section.tsx
@@ -4,7 +4,7 @@ import logo from '@/src/assets/images/(logo)/logo.png'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import Image from 'next/image'
-import Heart from '@/src/assets/icon/heart_fullfill_20.svg'
+import heart_fill from '@/src/assets/icon/heart_fullfill_20.svg'
 
 export function UserProfileSection({ user }: { user: UserSummaryType }) {
   const { user_id, profile_url, name, description, like_course_count } = user
@@ -27,7 +27,7 @@ export function UserProfileSection({ user }: { user: UserSummaryType }) {
         <p className='text-middle font-medium'>관심 코스 목록</p>
         <div className='flex flex-row justify-center items-center gap-[6px]'>
           <div className='flex flex-row gap-[4px]'>
-            <Image src={Heart as string} alt='heart' width={20} height={20} />
+            <Image src={heart_fill as string} alt='heart' width={20} height={20} />
             {like_course_count}
           </div>
           <ChevronRight className='text-description' size={24} />

--- a/src/widgets/header/action-header.tsx
+++ b/src/widgets/header/action-header.tsx
@@ -91,11 +91,11 @@ export function ActionHeader({
   }
 
   return (
-    <HeaderBase className='px-[10px] border-b-[1px] border-container-blue'>
+    <HeaderBase className='px-[10px] border-b-[1px] border-container-blue z-[30] sticky top-0'>
       {isTitleTag ? (
         <div
           className={`flex items-center ${
-            isTitleCenter ? 'w-full relative' : 'gap-[10px]'
+            isTitleCenter ? 'w-full relative justify-between' : 'gap-[10px] justify-center'
           }`}
         >
           <BackButton onClick={handleClickBack} />
@@ -110,6 +110,7 @@ export function ActionHeader({
               stroke='#5A59F2'
             />
           )}
+          {rightSection()}
         </div>
       ) : (
         <>
@@ -127,9 +128,9 @@ export function ActionHeader({
           >
             {title}
           </p>
+          {rightSection()}
         </>
       )}
-      {rightSection()}
     </HeaderBase>
   )
 }

--- a/src/widgets/header/action-header.tsx
+++ b/src/widgets/header/action-header.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { Heart } from 'lucide-react'
+import heart_fill from '@/src/assets/icon/heart_fullfill_20.svg'
+import heart_empty from '@/src/assets/icon/heart_empty_20.svg'
+import setting from '@/src/assets/icon/medium/setting.svg'
 import { useRouter, usePathname } from 'next/navigation'
 import { useEffect } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
 import React from 'react'
-import setting from '@/src/assets/images/setting.png'
 import useUserStore from '@/src/shared/store/userStore'
 import {
   HeaderBase,
@@ -65,14 +66,14 @@ export function ActionHeader({
     if (isUpdateUser && isMine) {
       return (
         <Link href={`/users/setting`}>
-          <Image width={24} height={24} alt='setting' src={setting} />
+          <Image width={24} height={24} alt='setting' src={setting as string} />
         </Link>
       )
     } else if (isListView !== undefined && setIsListView) {
       return (
         <ViewTypeToggleButton
           isListView={isListView}
-          onClick={() => setIsListView(!isListView)}
+          onClick={() => setIsListView && setIsListView(!isListView)}
         />
       )
     } else {
@@ -91,27 +92,51 @@ export function ActionHeader({
   }
 
   return (
-    <HeaderBase className='px-[10px] border-b-[1px] border-container-blue z-[30] sticky top-0'>
+    <HeaderBase className='px-[10px] border-b-[1px] border-container-blue z-[30] sticky top-0 flex justify-between items-center w-full max-w-[375px]'>
       {isTitleTag ? (
-        <div
-          className={`flex items-center ${
-            isTitleCenter ? 'w-full relative justify-between' : 'gap-[10px] justify-center'
-          }`}
-        >
-          <BackButton onClick={handleClickBack} />
-          <TitleWithTagStyle title={title} isTitleCenter={!!isTitleCenter} />
-          {showLike && (
-            <Heart
-              onClick={() => setIsLiked && setIsLiked(!isLiked)}
-              className='cursor-pointer'
-              size={20}
-              strokeWidth={1.5}
-              fill={isLiked ? '#5A59F2' : 'none'}
-              stroke='#5A59F2'
-            />
+        <>
+          {isTitleCenter ? (
+            <div className='relative flex items-center justify-between w-full'>
+              <BackButton onClick={handleClickBack} />
+              <TitleWithTagStyle title={title} isTitleCenter />
+              <div className='flex items-center'>
+                {showLike && (
+                  <Image
+                    src={
+                      isLiked ? (heart_fill as string) : (heart_empty as string)
+                    }
+                    alt='heart'
+                    className='cursor-pointer'
+                    onClick={() => setIsLiked && setIsLiked(!isLiked)}
+                    width={20}
+                    height={20}
+                  />
+                )}
+                {rightSection()}
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className='flex items-center gap-[10px]'>
+                <BackButton onClick={handleClickBack} />
+                <TitleWithTagStyle title={title} isTitleCenter={false} />
+                {showLike && (
+                  <Image
+                    src={
+                      isLiked ? (heart_fill as string) : (heart_empty as string)
+                    }
+                    alt='heart'
+                    className='cursor-pointer'
+                    onClick={() => setIsLiked && setIsLiked(!isLiked)}
+                    width={20}
+                    height={20}
+                  />
+                )}
+              </div>
+              {rightSection()}
+            </>
           )}
-          {rightSection()}
-        </div>
+        </>
       ) : (
         <>
           {isBack || close ? (

--- a/src/widgets/header/course-plan-header.tsx
+++ b/src/widgets/header/course-plan-header.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Heart } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState, useRef } from 'react'
 import React from 'react'
@@ -16,6 +15,9 @@ import {
 import { USER_QUERY_KEY } from '@/src/entities/user/api'
 import { HeaderBase, TitleWithTagStyle } from '@/src/features'
 import { useAuth } from '@/src/shared/provider'
+import heart_fill from '@/src/assets/icon/heart_fullfill_20.svg'
+import heart_empty from '@/src/assets/icon/heart_empty_20.svg'
+import Image from 'next/image'
 
 interface CoursePlanHeaderProps {
   title: string
@@ -112,13 +114,13 @@ export function CoursePlanHeader({
 
       <div className='flex items-center gap-[10px]'>
         {showLike && !isMine && (
-          <Heart
-            onClick={handleClickLike}
+          <Image
+            src={clickedLike ? (heart_fill as string) : (heart_empty as string)}
+            alt='heart'
             className='cursor-pointer'
-            size={20}
-            strokeWidth={1.5}
-            fill={clickedLike ? '#5A59F2' : 'none'}
-            stroke='#5A59F2'
+            onClick={handleClickLike}
+            width={20}
+            height={20}
           />
         )}
         {isMine && (


### PR DESCRIPTION
## 📝 개요

- #244  해결

## ✨ 변경 사항
  - ✨ 마이 페이지, 장소 상세 페이지의 Header에 sticky postion을 부여
  - ✨ toggle tab의 고정 위치 수정
  - 코드가 수정된 페이지에 포함된 외부 호출 icon을 자체 아이콘으로 수정


## 🔗 관련 이슈
- closes #244 

## 📸 스크린샷 (옵션)

### 마이페이지
![Animation5](https://github.com/user-attachments/assets/9afa571f-ad49-494e-bcd8-e4f2ee65620d)

### 장소
![Animation4](https://github.com/user-attachments/assets/8c7ff6db-4f28-49d4-8689-3dbd59039ad1)


