### PR TITLE
[수정] 리액트 쿼리 캐싱 관련 설정 수정 및 데이터타입 설정

### DIFF
--- a/src/entities/course/api/delete-course.ts
+++ b/src/entities/course/api/delete-course.ts
@@ -1,5 +1,4 @@
 import { customAxios } from '@/src/shared/api'
-import { COURSE_QUERY_KEY } from './queryKey'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { COURSE_URL } from './endpoint'
 
@@ -13,13 +12,17 @@ export const deleteCourse = async (id: string) => {
   }
 }
 
-export const useDeleteCourse = (id: string) => {
+export const useDeleteCourse = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (id: string) => deleteCourse(id),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: COURSE_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'courses' ||
+          query.queryKey[0] === 'userCourses',
+      })
     },
   })
 }

--- a/src/entities/course/api/post-course.ts
+++ b/src/entities/course/api/post-course.ts
@@ -20,7 +20,11 @@ export const usePostCourse = () => {
   return useMutation({
     mutationFn: (data: CoursePayloadType) => postCourse(data),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: COURSE_QUERY_KEY.post })
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'courses' ||
+          query.queryKey[0] === 'userCourses',
+      })
     },
   })
 }

--- a/src/entities/place/api/get-place.ts
+++ b/src/entities/place/api/get-place.ts
@@ -2,8 +2,9 @@ import { customAxios } from '@/src/shared/api'
 import { useQuery } from '@tanstack/react-query'
 import { PLACE_URL } from './endpoint'
 import { PLACE_QUERY_KEY } from './queryKey'
+import { PlaceType } from '../model'
 
-export const getPlace = async (id: string) => {
+export const getPlace = async (id: string): Promise<PlaceType> => {
   try {
     const response = await customAxios.get(PLACE_URL.detail(id))
     return response.data.results

--- a/src/entities/place/model/type.ts
+++ b/src/entities/place/model/type.ts
@@ -1,7 +1,7 @@
 import { WriterType } from '@/src/entities/user/model'
 
 export type PlaceType = {
-  id: number
+  id: string
   name: string
   latitude: number
   longitude: number
@@ -20,7 +20,7 @@ export type PlaceReviewStatsType = {
 }
 
 export interface PlaceReviewType {
-  id: number
+  id: string
   rating: number
   contents: string
   created_at: string
@@ -29,7 +29,7 @@ export interface PlaceReviewType {
 }
 
 export interface UserPlaceReviewType extends PlaceReviewType {
-  place_id: number
+  place_id: string
   place_name: string
 }
 

--- a/src/entities/plan/api/post-plan.ts
+++ b/src/entities/plan/api/post-plan.ts
@@ -20,7 +20,7 @@ export const usePostPlan = () => {
   return useMutation({
     mutationFn: (data: PlanPayloadType) => postPlan(data),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: PLAN_QUERY_KEY.all })
+      queryClient.invalidateQueries({ queryKey: PLAN_QUERY_KEY.all })
     },
   })
 }

--- a/src/entities/user/api/get-user-courses.ts
+++ b/src/entities/user/api/get-user-courses.ts
@@ -20,6 +20,7 @@ export const getUserCourses = async (
     throw error
   }
 }
+
 export const useGetUserCourses = (id: string, order?: 'RECENT' | 'POPULAR') => {
   return useQuery({
     queryKey: USER_QUERY_KEY.courses(id, order),

--- a/src/views/detail-place/index.tsx
+++ b/src/views/detail-place/index.tsx
@@ -102,7 +102,7 @@ export default function DetailPlace({ id }: { id: string }) {
         <ScrollTabs
           isScrollingRef={isScrollingRef}
           setActiveTab={setActiveTab}
-          tabs={tabs}
+          tabs={tabs ?? []}
           refs={{ info: infoRef, review: reviewRef }}
         />
         <Spacer height={26} />

--- a/src/widgets/header/course-plan-header.tsx
+++ b/src/widgets/header/course-plan-header.tsx
@@ -46,7 +46,7 @@ export function CoursePlanHeader({
 
   const { mutate: deleteCourseLike } = useDeleteCourseLike(id)
   const { mutate: postCourseLike } = usePostCourseLike(id)
-  const { mutate: deleteCourse } = useDeleteCourse(id)
+  const { mutate: deleteCourse } = useDeleteCourse()
   const { mutate: deletePlan } = useDeletePlan()
 
   const deleteCourseOrPlan = type === 'course' ? deleteCourse : deletePlan


### PR DESCRIPTION
## 📝 개요

- 리액트 쿼리 캐싱 설정을 수정하고, 서버 응답의 데이터타입을 설정했습니다.

## ✨ 변경 사항

  - ✨ 코스, 플랜, 댓글 삭제/수저: `refetchQueries` (-> 즉시 목록 업데이트)
  - ✨ 코스, 플랜, 댓글 추가: `invalidateQueries`
  - ✨ predicate: 쿼리키의 부분 일치로 invalidate하는 옵션
      - `queryClient.refetchQueries({ predicate: (query) => query.queryKey[0] === 'courses'})`
         : 쿼리키가 'courses'로 시작하는 모든 쿼리의 캐시 무효화
  - ✨ id라는 변수가 이외의 코드에서 대부분 string으로 사용되어, 데이터타입을 수정했습니다.

## 🔗 관련 이슈
-

## 📸 스크린샷 (옵션)

- UI 변경 사항이 있는 경우 스크린샷을 포함합니다.

## ℹ️ 참고 사항

|함수 | 설명 | 서버 요청 발생 시점|
|-- | -- | --|
|invalidateQueries | 쿼리를 무효화해서 다음 render 또는 focus 시 refetch되게 만듦 | ❌ 즉시 X, 조건 충족 시|
|refetchQueries | 쿼리를 즉시 서버로부터 재요청함 | ✅ 바로 발생|
