### PR TITLE
[수정] 코스 상세 페이지에서 댓글 KebabMenu 아이콘 미표시

### DIFF
--- a/src/features/comment-card/comment-card.tsx
+++ b/src/features/comment-card/comment-card.tsx
@@ -17,9 +17,15 @@ type CommentCardProps = {
   id: string
   content: CommentType
   refetch?: () => void
+  showKebab: boolean
 }
 
-export function CommentCard({ id, content, refetch }: CommentCardProps) {
+export function CommentCard({
+  id,
+  content,
+  refetch,
+  showKebab,
+}: CommentCardProps) {
   const { writer, contents, created_at } = content
   const { user } = useUserStore()
 
@@ -123,7 +129,7 @@ export function CommentCard({ id, content, refetch }: CommentCardProps) {
           </div>
         </Link>
 
-        {isMine && !isEditingComment && (
+        {isMine && !isEditingComment && showKebab && (
           <ActionDropdown
             type='comment'
             id={id}

--- a/src/views/detail-course/index.tsx
+++ b/src/views/detail-course/index.tsx
@@ -102,6 +102,7 @@ export default function DetailCourse({ courseId }: DetailCourseProps) {
                     id={comment.id}
                     content={comment}
                     refetch={refetch}
+                    showKebab={false}
                   />
                 )
               })}

--- a/src/views/list-comment/index.tsx
+++ b/src/views/list-comment/index.tsx
@@ -72,6 +72,7 @@ export default function DetailComment({ courseId }: { courseId: string }) {
               id={comment.id}
               content={comment}
               refetch={refetch}
+              showKebab={true}
             />
           )
         })}


### PR DESCRIPTION
## 📝 개요

- 코스 상세 페이지의 댓글 목록에서는 수정/삭제가 불가능하도록 했습니다. (지난 회의에서 논의)

## ✨ 변경 사항

  - ✨ `showKebab` props 추가

## 🔗 관련 이슈

- closes #263 

## 📸 스크린샷 (옵션)

-

## ℹ️ 참고 사항

- #275 PR에 의존성을 가지고 있는 변경사항이라, 빌드 테스트는 해당 PR 머지 이후에 해보겠습니다!
