### PR TITLE
[수정-코스,플랜 목록] 플로팅 버튼의 z-index 조정

### DIFF
--- a/src/features/floating-write-btn/floating-write-btn.tsx
+++ b/src/features/floating-write-btn/floating-write-btn.tsx
@@ -29,7 +29,7 @@ export function FloatingWriteButton({
   }
 
   return (
-    <div className='flex items-center justify-end cursor-pointer z-[50]'>
+    <div className='flex items-center justify-end cursor-pointer'>
       {isClick && (
         <div className='fixed w-full max-w-[390px] left-1/2 -translate-x-1/2 h-full top-0 left-0 bg-black opacity-30 z-[1000]' />
       )}


### PR DESCRIPTION
## ✨ 변경 사항

- 자식 요소의 z-index가 올바르게 적용될 수 있도록 부모 div에서 z-index 속성을 제거했습니다.
- 이로 인해 `FloatingWriteButton`의 background가 의도대로 header와 같은 [쌓임 맥락](https://developer.mozilla.org/ko/docs/Web/CSS/CSS_positioned_layout/Stacking_context)을 가집니다.

## 🔗 관련 이슈
  - resolves #274 

