### PR TITLE
[수정 및 기능] iOS 모바일에서 input, textarea 확대되는 문제 해결

### DIFF
--- a/src/features/comment-card/comment-card.tsx
+++ b/src/features/comment-card/comment-card.tsx
@@ -142,7 +142,7 @@ export function CommentCard({
       {isEditingComment ? (
         <section className='w-full flex flex-col gap-[10px]'>
           <form
-            className='w-full px-[10px] gap-[10px] py-[10px] bg-bright-gray rounded-[10px] flex items-center justify-between'
+            className='px-[10px] gap-[10px] py-[10px] bg-bright-gray rounded-[10px] flex items-center justify-between overflow-hidden group  focus-within:outline focus-within:outline-[2px] focus-within:outline-wooco_blue-primary-light'
             onSubmit={handleSubmit(onSubmit)}
           >
             <input
@@ -153,7 +153,7 @@ export function CommentCard({
               }}
               type='text'
               placeholder='댓글을 작성해주세요.'
-              className='w-full text-middle text-gray-800 bg-transparent focus:outline-none placeholder:text-sub placeholder:opacity-50'
+              className='text-main01 text-gray-800 bg-transparent focus:outline-none box-border scale-[0.875] origin-left w-[114.29%]'
             />
             <div className='z-[10001] fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[375px] h-[80px] flex flex-col items-center justify-center gap-[1px] bg-white text-gray-600 font-bold text-main'>
               <Spacer height={20} />

--- a/src/features/course-form/elements/contents.tsx
+++ b/src/features/course-form/elements/contents.tsx
@@ -1,5 +1,8 @@
+'use client'
+
 import { CoursePayloadType } from '@/src/entities/course'
 import { HelperText } from '@/src/shared/ui'
+import { useRef } from 'react'
 import { FieldErrors, UseFormRegister } from 'react-hook-form'
 
 export function FormContents({
@@ -9,6 +12,16 @@ export function FormContents({
   register: UseFormRegister<CoursePayloadType>
   errors: FieldErrors<CoursePayloadType>
 }) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const handleResize = () => {
+    const textarea = textareaRef.current
+    if (textarea) {
+      textarea.style.height = '148.57px' // Reset height to shrink if needed
+      textarea.style.height = `${textarea.scrollHeight}px` // Set height to scrollHeight
+    }
+  }
+
   const validateContents = (value: string) => {
     if (!value) return '내용을 입력해주세요.'
     if (value.length < 2 || value.length > 200) {
@@ -20,9 +33,11 @@ export function FormContents({
     <>
       <textarea
         {...register('contents', { validate: validateContents })}
-        className='rounded-[10px] h-[130px] resize-none focus:outline-container-light-blue focus:outline-[0.5px] border-0 bg-bright-gray p-[10px] text-sub text-gray-500'
+        ref={textareaRef}
+        className='rounded-[10px] resize-none focus:outline-container-light-blue focus:outline-[0.5px] border-0 bg-gray-100 p-[15px] text-main01 text-gray-800 scale-[0.875] h-[148.57px] w-[114.29%] origin-top-left'
         placeholder='방문 후기나 가기 전 꿀팁 등 다양한 정보가 있을수록 좋아요!'
         maxLength={200}
+        onInput={handleResize}
       />
       {errors.contents && (
         <HelperText message={errors.contents.message || ''} />

--- a/src/features/course-form/elements/title.tsx
+++ b/src/features/course-form/elements/title.tsx
@@ -22,7 +22,7 @@ export function FormTitle({
         {...register('title', { validate: validateTitle })}
         maxLength={20}
         placeholder='제목을 입력해주세요.'
-        className='rounded-full focus:outline-container-light-blue focus:outline-[0.5px] text-sub text-gray-500 h-[35px] border-0 bg-bright-gray px-[10px]'
+        className='rounded-full focus:outline-wooco_blue-primary-light focus:outline-[0.5px] text-main01 text-gray-800 border-0 bg-gray-100 px-[15px] scale-[0.875] h-[40px] w-[114.29%] origin-top-left'
       />
       {errors.title && <HelperText message={errors.title.message || ''} />}
     </>

--- a/src/features/place/form-review.tsx
+++ b/src/features/place/form-review.tsx
@@ -24,7 +24,7 @@ const ReviewTextarea: React.FC<ReviewTextareaProps> = ({
   const handleResize = () => {
     const textarea = textareaRef.current
     if (textarea) {
-      textarea.style.height = 'auto' // Reset height to shrink if needed
+      textarea.style.height = '80px' // Reset height to shrink if needed
       textarea.style.height = `${textarea.scrollHeight}px` // Set height to scrollHeight
     }
   }
@@ -35,20 +35,17 @@ const ReviewTextarea: React.FC<ReviewTextareaProps> = ({
   }
 
   return (
-    <div className='flex w-full justify-center items-center'>
-      <textarea
-        {...register('contents', {
-          required: '리뷰 내용은 필수 입력 항목입니다.',
-        })}
-        ref={textareaRef}
-        value={contents}
-        onChange={handleChange}
-        onInput={handleResize}
-        placeholder={`작성 tip:\n방문 후기나 가기 전 꿀팁 등 다양한 정보가 있을수록 좋아요!`}
-        className='w-[305px] h-[48px] px-[14px] py-[10px] rounded-[10px] bg-[#F7F7F7] text-main
-      placeholder:text-sub placeholder:font-light resize-none overflow-hidden'
-      />
-    </div>
+    <textarea
+      {...register('contents', {
+        required: '리뷰 내용은 필수 입력 항목입니다.',
+      })}
+      ref={textareaRef}
+      value={contents}
+      onChange={handleChange}
+      onInput={handleResize}
+      placeholder={`작성 tip:\n방문 후기나 가기 전 꿀팁 등 다양한 정보가 있을수록 좋아요!`}
+      className='w-[114.29%] h-[80px] px-[14px] py-[10px] rounded-[10px] bg-gray-100 border-0 text-main01 text-gray-800 resize-none focus:outline-container-light-blue focus:outline-[0.5px] scale-[0.875] origin-top'
+    />
   )
 }
 
@@ -88,7 +85,7 @@ const KeywordInput: React.FC<KeywordInputProps> = ({ keywords, setValue }) => {
           }
         }}
         placeholder='하나의 키워드로 설명해주세요! ex. 맛/가성비/역세권'
-        className='w-[305px] h-[36px] px-[14px] py-[10px] box-border rounded-[2025px] bg-[#F7F7F7] text-main placeholder:text-sub'
+        className='w-[114.29%] h-[40px] px-[14px] py-[10px] box-border rounded-full bg-[#F7F7F7] text-main01 focus:outline-wooco_blue-primary-light focus:outline-[0.5px] scale-[0.875] origin-top'
       />
       <div className='flex w-[305px] flex-wrap gap-[8px]'>
         {keywords.map((keyword, index) => (
@@ -189,7 +186,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
   return (
     <div className='w-full flex flex-col gap-2'>
       <div
-        className='w-[375px] overflow-x-scroll scroll-smooth cursor-grab'
+        className='w-full overflow-x-scroll scroll-smooth cursor-grab'
         ref={scrollRef}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
@@ -199,7 +196,7 @@ const ImageUploader: React.FC<ImageUploaderProps> = ({
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
       >
-        <div className='flex flex-row gap-[13px] px-[35px] mx-[-5px] min-w-fit'>
+        <div className='flex flex-row gap-[13px] mx-[-5px] min-w-fit'>
           <div className='relative w-[84px] h-[84px] flex justify-center items-center'>
             <button
               type='button'
@@ -302,28 +299,27 @@ const FormReview: React.FC<FormReviewProps> = ({
   }, [isSubmitting])
 
   return (
-    <div className='w-full bg-white flex flex-col gap-[10px]'>
+    <div className='w-full bg-white flex flex-col gap-[10px] px-[20px]'>
       {/* Star Rating Section */}
-      <div className='flex flex-col items-start justify-start gap-[15px] relative'>
-        <b className='text-main pl-[20px]'>별점을 남겨볼까요?</b>
+      <div className='flex flex-col items-center justify-center gap-[15px]'>
+        <b className='text-main w-full'>별점을 남겨볼까요?</b>
         <StarRateForm rate={formValues.rating} setValue={setValue} />
         <Spacer height={8} />
       </div>
 
       {/* Detailed Review Section */}
-      <div className='w-full flex flex-col items-start justify-start gap-[15px] relative'>
-        <b className='text-main pl-[20px]'>장소 리뷰를 적어주세요.</b>
+      <div className='w-full flex flex-col items-center justify-center gap-[15px]'>
+        <b className='text-main w-full'>장소 리뷰를 적어주세요.</b>
         <ReviewTextarea
           contents={formValues.contents}
           setValue={setValue}
           register={register}
         />
-        <Spacer height={8} />
       </div>
 
       {/* Keywords Section */}
-      <div className='w-full flex flex-col items-start justify-start gap-[15px]'>
-        <b className='text-main pl-[20px]'>어떤 점이 좋았나요?</b>
+      <div className='w-full flex flex-col items-center justify-center gap-[15px]'>
+        <b className='text-main w-full'>어떤 점이 좋았나요?</b>
         <KeywordInput
           keywords={formValues.one_line_reviews}
           setValue={setValue}
@@ -332,8 +328,8 @@ const FormReview: React.FC<FormReviewProps> = ({
       </div>
 
       {/* Image Upload Section */}
-      <div className='w-full flex flex-col items-start justify-start gap-[15px]'>
-        <b className='text-main pl-[20px]'>사진을 추가해보세요.</b>
+      <div className='w-full flex flex-col items-center justify-center gap-[15px]'>
+        <b className='text-main w-full'>사진을 추가해보세요.</b>
         <ImageUploader
           uploadedImages={formValues.image_urls}
           setValue={setValue}

--- a/src/views/list-comment/index.tsx
+++ b/src/views/list-comment/index.tsx
@@ -80,16 +80,19 @@ export default function DetailComment({ courseId }: { courseId: string }) {
       </div>
       <div className='shadow-custom bg-white max-w-[375px] fixed bottom-0 w-full h-[70px] px-[20px] flex items-center'>
         <form
-          className='w-full px-[15px] gap-[10px] h-[40px] border-[1px] border-brand bg-bright-gray rounded-full flex items-center justify-between'
+          className='w-full px-[15px] gap-[10px] h-[40px] border-[1px] border-brand bg-bright-gray rounded-full flex items-center justify-between relative'
           onSubmit={handleSubmit(onSubmit)}
         >
           <input
             {...register('contents')}
             type='text'
             placeholder='댓글을 작성해주세요.'
-            className='w-full h-full text-middle bg-transparent focus:outline-none placeholder:text-sub placeholder:opacity-50'
+            className='bg-transparent focus:outline-none text-main01 placeholder:opacity-50 box-border scale-[0.875] origin-left w-[114.29%] h-[45.71px]'
           />
-          <button type='submit'>
+          <button
+            type='submit'
+            className='absolute right-[15px] top-[50%] transform -translate-y-1/2'
+          >
             <Send
               size={20}
               className={isDirty ? 'text-brand' : 'text-dark-gray'}

--- a/src/views/onboard/index.tsx
+++ b/src/views/onboard/index.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react'
 import { FieldErrors, useForm, UseFormRegister } from 'react-hook-form'
 import { useGetMyProfile, useUpdateUser } from '@/src/entities/user'
 import { useRouter } from 'next/navigation'
-import { Spacer } from '@/src/shared/ui'
+import { HelperText, Spacer } from '@/src/shared/ui'
 
 export default function OnBoardView() {
   const router = useRouter()
@@ -70,6 +70,12 @@ export default function OnBoardView() {
         onSubmit={handleSubmit(onSubmit)}
       >
         <NicknameInput register={register} errors={errors} />
+        <button
+          type='submit'
+          className='text-white text-[15px] w-fit font-extrabold bottom-[144px] items-center justify-center absolute left-1/2 transform -translate-x-1/2'
+        >
+          시작하기
+        </button>
       </form>
     </div>
   )
@@ -92,27 +98,23 @@ function NicknameInput({ register, errors }: NicknameInputProps) {
   }
 
   return (
-    <div className='px-[20px] flex flex-col gap-[15px] items-start w-full'>
-      <div className='relative flex px-[20px] flex-col  w-full'>
-        <div className='text-white w-fit flex flex-col gap-[8px]'>
-          <p className='text-[20px] font-bold'>닉네임</p>
-          <p className='text-[13px]'>사용하실 닉네임을 작성해주세요.</p>
-        </div>
-        <Spacer height={15} />
-        <input
-          type='text'
-          {...register('nickname', { validate: validateNickname })}
-          className='w-full inline-block text-[13px] focus:outline-none bg-bright-gray px-[15px] py-[10px] rounded-full'
-          placeholder='한글, 영어, 숫자만 사용 가능'
-          autoFocus
-        />
-        <div className='h-[16px] mt-[5px]'>
-          {errors.nickname && (
-            <span className='text-[12px] text-red-500 font-bold'>
-              {errors.nickname.message}
-            </span>
-          )}
-        </div>
+    <div className='px-[40px] flex flex-col items-start w-full'>
+      <div className='text-white w-fit flex flex-col'>
+        <p className='text-headline01 font-bold'>닉네임</p>
+        <p className='text-middle'>사용하실 닉네임을 작성해주세요.</p>
+      </div>
+      <Spacer height={23} />
+      <input
+        type='text'
+        {...register('nickname', { validate: validateNickname })}
+        className='w-full h-[40px] inline-block text-main text-gray-600 font-bold placeholder:font-normal focus:outline-none bg-gray-100 px-[15px] py-[10px] rounded-full'
+        placeholder='한글, 영어, 숫자만 사용 가능'
+        autoFocus
+      />
+      <div className='h-[16px] mt-[5px]'>
+        {errors.nickname && (
+          <HelperText message={errors.nickname.message || ''} />
+        )}
       </div>
     </div>
   )

--- a/src/views/search-place/index.tsx
+++ b/src/views/search-place/index.tsx
@@ -72,24 +72,23 @@ export default function SearchPlace({
       />
       <Spacer height={18} />
       <div className='px-[20px] w-full flex flex-col gap-[15px]'>
-        <div className='flex flex-col gap-[15px]'>
-          <span className='text-main font-semibold'>장소명</span>
-          <div className='flex items-center justify-center '>
-            <div className='w-[304px] h-[36px] px-[14px] py-[10px] relative rounded-[2025px] bg-bright-gray flex flex-row items-center justify-start box-border gap-[10px]'>
-              <Search width={14} size={14} />
-              <input
-                className='relative font-medium text-middle text-black bg-transparent outline-0'
-                placeholder='장소 이름을 입력해주세요.'
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.nativeEvent.isComposing) return
-                  if (e.key === 'Enter') {
-                    getResult(inputValue)
-                  }
-                }}
-              />
-            </div>
+        <div className='flex flex-col gap-[15px] items-center justify-center'>
+          <span className='text-main font-semibold w-full'>장소명</span>
+          <div className='w-[304px] h-[36px] px-[14px] py-[10px] rounded-full bg-gray-100 flex flex-row items-center justify-start box-border gap-[10px] focus:outline-container-light-blue focus:outline-[0.5px]'>
+            <Search width={14} size={14} />
+            <input
+              className='w-[114.29%] flex-1 text-main01 text-gray-800 bg-transparent outline-0 scale-[0.875] origin-left outline-none'
+              placeholder='장소 이름을 입력해주세요.'
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing) return
+                if (e.key === 'Enter') {
+                  getResult(inputValue)
+                }
+              }}
+              autoFocus
+            />
           </div>
           <Spacer height={8} className='bg-bright-gray opacity-50' />
         </div>

--- a/src/views/update-user/index.tsx
+++ b/src/views/update-user/index.tsx
@@ -135,7 +135,7 @@ export default function UpdateUser() {
               <input
                 type='text'
                 {...register('nickname', { validate: validateNickname })}
-                className='w-full inline-block text-middle01 focus:outline-none bg-bright-gray px-[15px] py-[10px] rounded-full'
+                className='w-[114.29%] h-[114.29%] inline-block text-main01 focus:outline-none bg-bright-gray px-[15px] py-[10px] rounded-full scale-[0.875] origin-top-left'
                 placeholder='닉네임을 입력해주세요.'
               />
               {errors.nickname && (
@@ -152,7 +152,7 @@ export default function UpdateUser() {
               <input
                 type='text'
                 {...register('description', { validate: validateDescription })}
-                className='w-full inline-block text-[13px] focus:outline-none bg-bright-gray px-[15px] py-[10px] rounded-full'
+                className='w-[114.29%] h-[114.29%] inline-block text-main01 focus:outline-none bg-bright-gray px-[15px] py-[10px] rounded-full scale-[0.875] origin-top-left'
                 placeholder='소개를 입력해주세요.'
               />
               {errors.description && (
@@ -164,8 +164,10 @@ export default function UpdateUser() {
           </div>
           {!isOnBoarding && (
             <div className='fixed bottom-[70px] flex items-center mt-[20px] text-middle01 text-gray-600 gap-[10px]'>
-              <button onClick={handleLogout} className='hover:underline'>로그아웃</button>|
-              <button className='hover:underline'>회원탈퇴</button>
+              <button onClick={handleLogout} className='hover:underline'>
+                로그아웃
+              </button>
+              |<button className='hover:underline'>회원탈퇴</button>
             </div>
           )}
           <button


### PR DESCRIPTION
## 📝 개요

- iOS 모바일에서 입력 시도 시 화면이 확대되는 문제를 해결했습니다.
- 세부적인 디자인을 수정했습니다.

## ✨ 변경 사항

  - ✨ input, textarea의 text 크기 및 전체적인 비율 조정
      - 타겟 텍스트 크기가 11px 이라면, 16px로 설정해둔 후 `scale=0.6875` 설정 (11/16=0.6875)
      - width, height 등등도 같은 비율로 조정
  - ✨ 온보딩 페이지의 디자인을 반영하기 위해 '시작하기' 버튼을 추가했습니다.
  - ✨ 리뷰 작성 영역을 참고하여 코스 작성 페이지의 상세 설명 영역에도 `handleResize` 적용

## 🔗 관련 이슈

closes #116 

## 📸 스크린샷 (옵션)

- 모바일 로컬 서버로는 로그인된 상태로 테스트해볼 수가 없어서 (로컬 서버가 dev 서버와 연결되어 있음)
- 메인 페이지에 필요한 부분들만 몰아서 넣고 테스트 해본 영상입니다.

__상단이 기존 입력창, 하단이 비율 조정된 입력창입니다__


https://github.com/user-attachments/assets/68a9d199-e8aa-4341-9a62-3ff049e85569


## ℹ️ 참고 사항

- 아직 머지되지 않은 PR들과 충돌 가능성이 있어서 나중에 머지되는 PR만 주의하면 될 것 같습니다!
