### PR TITLE
[HOTFIX] 기본 프로필 이미지 깨짐 문제 해결

### DIFF
--- a/src/features/place-review/image-view.tsx
+++ b/src/features/place-review/image-view.tsx
@@ -74,7 +74,7 @@ export function ImageView({
         <div className='w-full h-[60px] px-[20px] py-[10px] text-white bg-brand'>
           <div className='w-full flex gap-[10px] max-w-[375px] cursor-pointer'>
             <ProfileImage
-              src={writer.profile_url || './profile.png'}
+              src={writer.profile_url || '/profile.png'}
               size={40}
               userId={writer.id}
             />

--- a/src/views/detail-course/index.tsx
+++ b/src/views/detail-course/index.tsx
@@ -63,7 +63,7 @@ export default function DetailCourse({ courseId }: DetailCourseProps) {
       <section className='w-full px-[20px] py-[10px] text-white bg-brand'>
         <div className='w-full flex gap-[10px] max-w-[375px] cursor-pointer'>
           <ProfileImage
-            src={course.writer.profile_url || './profile.png'}
+            src={course.writer.profile_url || '/profile.png'}
             size={40}
             userId={course.writer.id}
           />


### PR DESCRIPTION
## 📝 개요

- 코스 상세 페이지, 장소 리뷰에서 기본 프로필 이미지 깨짐 문제 해결을 위한 PR

## ✨ 변경 사항

  - ✨ 이미지 경로 수정

## 스크린샷

|기존|변경 후|
|---|---|
|![](https://github.com/user-attachments/assets/2bb781b8-627d-4401-a757-b48a9b8646ca)|![](https://github.com/user-attachments/assets/60f9175d-6c95-4e62-96c8-ff2b3f1e43cf)|
