### PR TITLE
[리팩토링] 코스 목록 페이지 URL 수정

### DIFF
--- a/app/courses/by-region/page.tsx
+++ b/app/courses/by-region/page.tsx
@@ -1,5 +1,0 @@
-import ListCourse from '@/src/views/list-course'
-
-export default function Page() {
-  return <ListCourse />
-}

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import MainCourse from '@/src/views/main-course'
+import ListCourse from '@/src/views/list-course'
+import { Suspense } from 'react'
+import Error from '@/app/error'
 
 export default function Page() {
-  return <MainCourse />
+  return (
+    <Suspense fallback={<Error />}>
+      <ListCourse />
+    </Suspense>
+  )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { MainHeader } from '@/src/widgets'
 import DefaultFooter from '@/src/widgets/default-footer'
 import localFont from 'next/font/local'
 import { AppProviders } from '@/src/shared/provider'
+import { Suspense } from 'react'
 
 export const metadata: Metadata = {
   title: 'WOOCO - 우코',
@@ -32,7 +33,9 @@ export default function RootLayout({
         className={`${pretendard.className} h-full flex items-center flex-col overflow-y-scroll`}
       >
         <AppProviders>
-          <MainHeader />
+          <Suspense fallback={null}>
+            <MainHeader />
+          </Suspense>
           <div className='mx-auto flex-1 text-black h-full w-full max-w-[375px]'>
             {children}
             <Spacer height={60} notShowURLs={['/login']} />

--- a/src/views/list-course/index.tsx
+++ b/src/views/list-course/index.tsx
@@ -1,139 +1,15 @@
-'use client'
-
-import { useEffect, useMemo, useState } from 'react'
-import { ActionHeader } from '@/src/widgets'
-import { useGetCourses } from '@/src/entities/course'
-import useRegionStore, { LikeRegion } from '@/src/shared/store/regionStore'
-import CourseListLayout from '@/src/widgets/course-list-layout'
-import { Spacer, SelectCategories, useToast } from '@/src/shared/ui'
-import { useDeleteMyLikeRegion, usePostMyLikeRegion } from '@/src/entities/user'
-import { SelectSort, FloatingWriteButton } from '@/src/features'
-import { useAuth } from '@/src/shared/provider'
+import { useSearchParams } from 'next/navigation'
+import MainCourse from './main-course'
+import RegionCourse from './region-course'
 
 export default function ListCourse() {
-  const [isListView, setIsListView] = useState(true)
-  const [order, setOrder] = useState<'RECENT' | 'POPULAR'>('RECENT')
-  const { selectedRegion, likedRegions, addLikedRegion, removeLikedRegion } =
-    useRegionStore()
-  const [isLiked, setIsLiked] = useState(false)
-  const [category, setCategory] = useState<string[]>(['ALL'])
-  const { show } = useToast()
-  const { token } = useAuth()
+  const path = useSearchParams()
+  const primary = path.get('primary')
+  const secondary = path.get('secondary')
 
-  const regionId = useMemo(() => {
-    return findLikedRegionId(likedRegions, selectedRegion)
-  }, [likedRegions, selectedRegion])
-
-  useEffect(() => {
-    setIsLiked(!!regionId)
-  }, [likedRegions, regionId])
-
-  useEffect(() => {
-    const isListView = sessionStorage.getItem('is-list')
-    if (isListView) {
-      setIsListView(isListView === 'true')
-    }
-  }, [])
-
-  const { mutate: postLikeMutate } = usePostMyLikeRegion()
-  const { mutate: deleteLikeMutate } = useDeleteMyLikeRegion()
-  const { data: courses, isLoading } = useGetCourses({
-    sort: order as 'RECENT' | 'POPULAR',
-    primary_region: selectedRegion[0],
-    secondary_region: selectedRegion[1],
-    category: category.includes('ALL') ? undefined : category[0],
-  })
-
-  const handleClickLike = () => {
-    if (!token) {
-      show('로그인 후 이용해주세요')
-      return
-    }
-
-    if (isLiked) {
-      setIsLiked(false)
-
-      deleteLikeMutate(regionId, {
-        onSuccess: () => {
-          removeLikedRegion(regionId)
-        },
-      })
-    } else {
-      setIsLiked(true)
-
-      postLikeMutate(
-        {
-          primary_region: selectedRegion[0],
-          secondary_region: selectedRegion[1],
-        },
-        {
-          onSuccess: (data) => {
-            addLikedRegion({
-              id: data.id,
-              primary_region: selectedRegion[0],
-              secondary_region: selectedRegion[1],
-            })
-          },
-        }
-      )
-    }
+  if (!primary || !secondary) {
+    return <MainCourse />
+  } else {
+    return <RegionCourse primary={primary} secondary={secondary} />
   }
-
-  const handleSetIsListView = (isListView: boolean) => {
-    setIsListView(isListView)
-    sessionStorage.setItem('is-list', String(isListView))
-  }
-
-  useEffect(() => {
-    // 로딩 중일때 스크롤 금지
-    if (isLoading) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = 'unset'
-    }
-  }, [isLoading])
-
-  return (
-    <>
-      <ActionHeader
-        title={selectedRegion[1] as string}
-        isTitleTag={true}
-        isBack
-        isListView={isListView}
-        setIsListView={handleSetIsListView}
-        showLike={true}
-        isLiked={isLiked}
-        setIsLiked={handleClickLike}
-      />
-      <SelectCategories
-        isInCourseList={true}
-        prevCategories={category}
-        setCategories={(category: string[]) => {
-          setCategory(category)
-        }}
-      />
-      <Spacer height={10} />
-      <div className='w-full flex flex-col px-[22px] gap-[10px] justify-center items-start'>
-        <SelectSort order={order} setOrder={setOrder} />
-        <CourseListLayout
-          isListView={isListView}
-          courses={isLoading ? undefined : courses}
-        />
-      </div>
-      <FloatingWriteButton />
-    </>
-  )
-}
-
-const findLikedRegionId = (
-  likedRegions: LikeRegion[],
-  currentRegion: string[]
-): string => {
-  const matchedRegion = likedRegions.find(
-    (region) =>
-      region.primary_region === currentRegion[0] &&
-      region.secondary_region === currentRegion[1]
-  )
-
-  return matchedRegion ? matchedRegion.id : ''
 }

--- a/src/views/list-course/main-course.tsx
+++ b/src/views/list-course/main-course.tsx
@@ -27,7 +27,7 @@ export default function MainCourse() {
 
   const onChangeRegion = (value: string[]) => {
     setSelectedRegion(value)
-    router.push(`/courses/by-region`)
+    router.push(`/courses?primary=${value[0]}&secondary=${value[1]}`)
   }
 
   useEffect(() => {

--- a/src/views/list-course/region-course.tsx
+++ b/src/views/list-course/region-course.tsx
@@ -1,0 +1,149 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { ActionHeader } from '@/src/widgets'
+import { useGetCourses } from '@/src/entities/course'
+import useRegionStore, { LikeRegion } from '@/src/shared/store/regionStore'
+import CourseListLayout from '@/src/widgets/course-list-layout'
+import { Spacer, SelectCategories, useToast } from '@/src/shared/ui'
+import { useDeleteMyLikeRegion, usePostMyLikeRegion } from '@/src/entities/user'
+import { SelectSort, FloatingWriteButton } from '@/src/features'
+import { useAuth } from '@/src/shared/provider'
+
+interface RegionCourseProps {
+  primary: string
+  secondary: string
+}
+
+export default function RegionCourse({
+  primary,
+  secondary,
+}: RegionCourseProps) {
+  const [isListView, setIsListView] = useState(true)
+  const [order, setOrder] = useState<'RECENT' | 'POPULAR'>('RECENT')
+  const { likedRegions, addLikedRegion, removeLikedRegion } = useRegionStore()
+  const [isLiked, setIsLiked] = useState(false)
+  const [category, setCategory] = useState<string[]>(['ALL'])
+  const { show } = useToast()
+  const { token } = useAuth()
+
+  const regionId = useMemo(() => {
+    return findLikedRegionId(likedRegions, [
+      primary as string,
+      secondary as string,
+    ])
+  }, [likedRegions, primary, secondary])
+
+  useEffect(() => {
+    setIsLiked(!!regionId)
+  }, [likedRegions, regionId])
+
+  useEffect(() => {
+    const isListView = sessionStorage.getItem('is-list')
+    if (isListView) {
+      setIsListView(isListView === 'true')
+    }
+  }, [])
+
+  const { mutate: postLikeMutate } = usePostMyLikeRegion()
+  const { mutate: deleteLikeMutate } = useDeleteMyLikeRegion()
+  const { data: courses, isLoading } = useGetCourses({
+    sort: order as 'RECENT' | 'POPULAR',
+    primary_region: primary as string,
+    secondary_region: secondary as string,
+    category: category.includes('ALL') ? undefined : category[0],
+  })
+
+  const handleClickLike = () => {
+    if (!token) {
+      show('로그인 후 이용해주세요')
+      return
+    }
+
+    if (isLiked) {
+      setIsLiked(false)
+
+      deleteLikeMutate(regionId, {
+        onSuccess: () => {
+          removeLikedRegion(regionId)
+        },
+      })
+    } else {
+      setIsLiked(true)
+
+      postLikeMutate(
+        {
+          primary_region: primary as string,
+          secondary_region: secondary as string,
+        },
+        {
+          onSuccess: (data) => {
+            addLikedRegion({
+              id: data.id,
+              primary_region: primary as string,
+              secondary_region: secondary as string,
+            })
+          },
+        }
+      )
+    }
+  }
+
+  const handleSetIsListView = (isListView: boolean) => {
+    setIsListView(isListView)
+    sessionStorage.setItem('is-list', String(isListView))
+  }
+
+  useEffect(() => {
+    // 로딩 중일때 스크롤 금지
+    if (isLoading) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'unset'
+    }
+  }, [isLoading])
+
+  return (
+    <>
+      <ActionHeader
+        title={secondary as string}
+        isTitleTag={true}
+        isBack
+        isListView={isListView}
+        setIsListView={handleSetIsListView}
+        showLike={true}
+        isLiked={isLiked}
+        setIsLiked={handleClickLike}
+      />
+      <SelectCategories
+        isInCourseList={true}
+        prevCategories={category}
+        setCategories={(category: string[]) => {
+          setCategory(category)
+        }}
+      />
+      <Spacer height={10} />
+      <div className='w-full flex flex-col px-[22px] gap-[10px] justify-center items-start'>
+        <SelectSort order={order} setOrder={setOrder} />
+        <CourseListLayout
+          isListView={isListView}
+          courses={isLoading ? undefined : courses}
+        />
+      </div>
+      <FloatingWriteButton />
+    </>
+  )
+}
+
+const findLikedRegionId = (
+  likedRegions: LikeRegion[],
+  currentRegion: string[]
+): string => {
+  const matchedRegion = likedRegions.find(
+    (region) =>
+      region.primary_region === currentRegion[0] &&
+      region.secondary_region === currentRegion[1]
+  )
+
+  return matchedRegion ? matchedRegion.id : ''
+}

--- a/src/widgets/header/main-header.tsx
+++ b/src/widgets/header/main-header.tsx
@@ -3,19 +3,20 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import logo from '@/src/assets/icon/small(20)/logo.svg'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import bell from '@/public/bell.svg'
 import { Spacer, useToast } from '@/src/shared/ui'
 import { useAuth } from '@/src/shared/provider'
 
 export function MainHeader() {
   const path = usePathname()
+  const params = useSearchParams()
   const router = useRouter()
   const { show } = useToast()
   const { token } = useAuth()
 
-  const isCourse = path.endsWith('/courses')
-  const isPlan =path.endsWith('/plans')
+  const isCourse = path.endsWith('/courses') && !params.get('primary')
+  const isPlan = path.endsWith('/plans')
 
   const isShowHeader =
     path === '/' || path === '/not-found' || isCourse || isPlan


### PR DESCRIPTION
## 📝 개요

- 코스 목록 페이지의 URL 구조를 RESTful하게 개편하고, 지역별 코스 목록의 컴포넌트 구조를 개선했습니다.

## ✨ 변경 사항

✨ 코스 목록 페이지의 경로 변경 및 RESTful URL 적용
- 기존 `/courses/by-region`에서 쿼리 파라미터(`?primary=...&secondary=...`) 기반으로 구조를 변경하여, URL 명확성과 관리 효율성을 높였습니다.
- 지역별 코스 목록을 별도의 RegionCourse 컴포넌트로 분리하고, 전체 코스/메인 리스트 로직 정리

✨ 헤더 표시하는 링크 수정
- useSearchParams로 쿼리 파라미터 존재 여부 판단 -> Suspense 적용

## 🔗 관련 이슈

-

## 📸 스크린샷 (옵션)

-

## ℹ️ 참고 사항

- 이전 PR(#308)에 의존성을 가지고 있는 변경사항이라, 빌드 테스트는 이전 PR 머지 후에 재테스트 해보겠습니다.
