### PR TITLE
[기능] iOS 기기 감지 훅 detectMobileOS 추가

### DIFF
--- a/src/features/floating-write-btn/floating-write-btn.tsx
+++ b/src/features/floating-write-btn/floating-write-btn.tsx
@@ -4,6 +4,7 @@ import { Pencil, X } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { FloatingMenuButton } from '@/src/features'
+import { useIsIOS } from '@/src/shared/utils/detectMobileOS'
 
 interface FloatingWriteButtonProps {
   isClick?: boolean
@@ -15,6 +16,7 @@ export function FloatingWriteButton({
   setIsClick: setIsClickProp,
 }: FloatingWriteButtonProps) {
   const router = useRouter()
+  const isIOS = useIsIOS()
   const [internalIsClick, setInternalIsClick] = useState(false)
 
   const isClick = isClickProp ?? internalIsClick
@@ -33,7 +35,9 @@ export function FloatingWriteButton({
       {isClick && (
         <div className='fixed w-full max-w-[390px] left-1/2 -translate-x-1/2 h-full top-0 left-0 bg-black opacity-30 z-[1000]' />
       )}
-      <div className='fixed flex flex-col gap-[20px] items-end bottom-[80px] z-[1001] pr-[20px]'>
+      <div
+        className={`fixed flex flex-col gap-[20px] items-end z-[1001] pr-[20px] ${isIOS ? 'bottom-[100px]' : 'bottom-[80px]'}`}
+      >
         {isClick && (
           <div className='flex flex-col gap-[10px]'>
             <FloatingMenuButton

--- a/src/shared/utils/detectMobileOS.tsx
+++ b/src/shared/utils/detectMobileOS.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+export type MobileOS = 'A' | 'I' | null
+
+export const detectMobileOS = (): MobileOS => {
+  if (typeof window === 'undefined') return null // 서버에서 실행 방지
+
+  const userAgent = navigator.userAgent
+
+  if (/android/i.test(userAgent)) {
+    return 'A'
+  }
+
+  if (/iPad|iPhone|iPod/.test(userAgent)) {
+    return 'I'
+  }
+
+  return null
+}
+
+import { useState, useEffect } from 'react'
+
+export const useIsIOS = () => {
+  const [isIOS, setIsIOS] = useState(false)
+
+  useEffect(() => {
+    setIsIOS(detectMobileOS() === 'I')
+  }, [])
+
+  return isIOS
+}

--- a/src/widgets/default-footer/index.tsx
+++ b/src/widgets/default-footer/index.tsx
@@ -9,10 +9,13 @@ import { Home, SquareChartGantt, UserRound } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { customAxios } from '@/src/shared/api'
 import useUserStore from '@/src/shared/store/userStore'
+import { useIsIOS } from '@/src/shared/utils/detectMobileOS'
 
 export default function DefaultFooter() {
   const path = usePathname()
   const router = useRouter()
+  const isIOS = useIsIOS()
+
   const isHome = path === '/'
   const isCourse = path?.includes('/courses')
   const isPlan = path?.includes('/plans')
@@ -51,7 +54,9 @@ export default function DefaultFooter() {
     return null
 
   return (
-    <footer className='fixed bottom-0 z-1000 shadow-custom max-w-[375px] text-black text-base bg-white flex w-full h-[60px] justify-around items-center'>
+    <footer
+      className={`fixed bottom-0 z-1000 shadow-custom max-w-[375px] text-black text-base bg-white flex w-full justify-around ${isIOS ? 'h-[78px] items-start pt-[10px]' : 'h-[60px] items-center'}`}
+    >
       <Link href='/' className='flex flex-col items-center'>
         <Home
           size={25}


### PR DESCRIPTION
## 📝 개요

- 모바일 기기를 감지하는 훅을 추가하여, 하단 메뉴 네비게이션바 관련 모바일 뷰를 개선했습니다.

## ✨ 변경 사항

- iOS 모바일 기기일 경우, 네비게이션 바의 높이와 플로팅 버튼의 위치를 수정

## 🔗 관련 이슈

- closes #310 

## 📸 스크린샷 (옵션)

|기존|변경 후|
|---|---|
|![image](https://github.com/user-attachments/assets/718f3993-bcb9-4bdf-8dd7-a672db923b26)|![IMG_2590](https://github.com/user-attachments/assets/8defb44c-30db-4028-ada2-5adf2a9020cf)|


## ℹ️ 참고 사항

- 
