### PR TITLE
[수정] 코스 수정 권한 확인 로직 추가

### DIFF
--- a/src/views/detail-course/index.tsx
+++ b/src/views/detail-course/index.tsx
@@ -23,7 +23,7 @@ export default function DetailCourse({ courseId }: DetailCourseProps) {
     data: course,
     isLoading: isCourseLoading,
     isError,
-  } = useGetCourse(courseId)
+  } = useGetCourse(courseId, true)
   const {
     data: comments,
     isLoading: isCommentLoading,

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -23,8 +23,8 @@ import {
   useUpdateCourse,
 } from '@/src/entities/course'
 import { useQueryClient } from '@tanstack/react-query'
-import useRegionStore from '@/src/shared/store/regionStore'
 import { useToast } from '@/src/shared/provider'
+import useUserStore from '@/src/shared/store/userStore'
 
 const LAYOUT_TYPE = {
   course: 'course' as const,
@@ -97,8 +97,8 @@ export default function CoursePlanFormLayout({
     return type === LAYOUT_TYPE.course
       ? courseData
       : type === LAYOUT_TYPE.plan
-      ? planData
-      : null
+        ? planData
+        : null
   }, [type, courseData, planData])
 
   useEffect(() => {
@@ -111,7 +111,15 @@ export default function CoursePlanFormLayout({
       contents,
       visit_date,
       places,
+      writer,
     } = fetchData
+
+    const { user } = useUserStore.getState()
+    if (!user || writer.id !== user?.user_id) {
+      router.push(`/${type}s/${id}`)
+      show('warning', '수정 권한이 없습니다.')
+      return
+    }
 
     setValue('title', title)
     setValue('primary_region', primary_region)


### PR DESCRIPTION
## 📝 개요

- 사용자가 URL에 직접 `/update`를 입력해 본인이 작성하지 않은 코스의 수정 페이지에 접근하려 할 때, 해당 코스의 상세 페이지로 자동 이동시키는 기능을 추가했습니다.

## ✨ 변경 사항

✨ 작성자 ID와 현재 로그인한 사용자 ID 비교 로직 추가
- 두 값이 다를 경우, 수정 페이지 접근을 차단하고 상세 페이지로 이동
- 토스트 메시지 노출
 
✨ 코스 정보 조회 API의 캐싱 최적화
- React Query의 캐싱을 활용하여 getCourse의 props를 일관되게 부여

## 🔗 관련 이슈

- closes #305 

## 📸 스크린샷 (옵션)



https://github.com/user-attachments/assets/eb393536-a9f2-49dd-ac6e-3e63605576e0


## ℹ️ 참고 사항

- #313  PR에 의존성이 있는 변경사항이라, 추후에 재빌드 테스트해본 후에 머지하겠습니다!
- 조회 성능 개선이 필요해보입니다...ㅠㅠ