### PR TITLE
[기능] 코스에 등록할 수 있는 장소 개수 5개로 제한

### DIFF
--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -241,6 +241,12 @@ export default function CoursePlanFormLayout({
 
   const handleClickSearchPlace = () => {
     const selectRegion = getValues('secondary_region')
+    const placesLength = places.length
+    if (placesLength >= 5) {
+      show('notice', '장소는 최대 5개까지 선택할 수 있습니다.')
+      return
+    }
+
     if (selectRegion) {
       setOpenSearchPlace(true)
     } else {


### PR DESCRIPTION
## 📝 개요

- 코스에 등록할 수 있는 최대 장소 개수를 5개로 제한하는 로직을 추가했습니다.

## ✨ 변경 사항

  - ✨ 장소 추가 버튼 클릭 시 장소 개수 5개 이하인지 검토하는 로직 추가

## 🔗 관련 이슈

- closes #297 


## 📸 스크린샷 (옵션)

https://github.com/user-attachments/assets/3d0609c1-cea0-4703-9cbe-96829d914369


## ℹ️ 참고 사항

- #313 PR 의존성 가지고 있습니다. 추후에 빌드 테스트 다시 해보고 머지하겠습니다.
