### PR TITLE
[수정-콘솔 경고] 중복된 key 값에 대한 경고 해소 

### DIFF
--- a/src/shared/provider/AppProviders.tsx
+++ b/src/shared/provider/AppProviders.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ReactNode } from 'react'
+import { cloneElement, ReactNode } from 'react'
 import {
   AuthProvider,
   ReactQueryProvider,
@@ -25,8 +25,14 @@ export function AppProviders({ children }: { children: ReactNode }) {
     <AuthProvider>
       <ReactQueryProvider>
         <ToastProvider>
-          <ConfigProvider theme={theme}>
-            <AnimatePresence>{children}</AnimatePresence>
+          <ConfigProvider theme={theme} key='theme'>
+            <AnimatePresence>
+              {Array.isArray(children)
+                ? children.map((child, index) =>
+                    cloneElement(child, { key: child.key ?? index })
+                  )
+                : children}
+            </AnimatePresence>
           </ConfigProvider>
         </ToastProvider>
       </ReactQueryProvider>


### PR DESCRIPTION
## ✨ 변경 사항
  - ✨ 이슈 발생은 children이 배열로 전달될 때, key가 비어있어 모두 `Empty String`로 반영되었기 때문
  - ✨ Provider로 전달된 children props가 배열인지 단일 노드인지 판정
  - ✨ 배열의 경우 index값을 임시로 각 요소에 unique key 부여



## 📸 스크린샷 (옵션)

![image](https://github.com/user-attachments/assets/34ca677e-d5ef-469f-bc61-ce8b434a2a7e)

