### PR TITLE
[리팩토링] React Query 쿼리 키 및 refetch 로직 개선

### DIFF
--- a/src/entities/comment/api/delete-comment.ts
+++ b/src/entities/comment/api/delete-comment.ts
@@ -13,13 +13,15 @@ export const deleteComment = async (id: string): Promise<number> => {
   }
 }
 
-export const useDeleteComment = (id: string) => {
+export const useDeleteComment = (course_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (id: string) => deleteComment(id),
+    mutationFn: (comment_id: string) => deleteComment(comment_id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: COMMENT_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({
+        queryKey: COMMENT_QUERY_KEY.all(course_id),
+      })
     },
   })
 }

--- a/src/entities/comment/api/get-comments.ts
+++ b/src/entities/comment/api/get-comments.ts
@@ -14,9 +14,9 @@ export const getComments = async (courseId: string): Promise<CommentType[]> => {
   }
 }
 
-export const useGetComments = (id: string) => {
+export const useGetComments = (course_id: string) => {
   return useQuery({
-    queryKey: COMMENT_QUERY_KEY.detail(id),
-    queryFn: () => getComments(id),
+    queryKey: COMMENT_QUERY_KEY.all(course_id),
+    queryFn: () => getComments(course_id),
   })
 }

--- a/src/entities/comment/api/post-comment.ts
+++ b/src/entities/comment/api/post-comment.ts
@@ -19,14 +19,19 @@ export const postComment = async (
   }
 }
 
-export const usePostComment = () => {
+export const usePostComment = (course_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ id, contents }: { id: string; contents: string }) =>
-      postComment(id, contents),
+    mutationFn: ({
+      course_id,
+      contents,
+    }: {
+      course_id: string
+      contents: string
+    }) => postComment(course_id, contents),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: COMMENT_QUERY_KEY.all })
+      queryClient.refetchQueries({ queryKey: COMMENT_QUERY_KEY.all(course_id) })
     },
   })
 }

--- a/src/entities/comment/api/queryKey.ts
+++ b/src/entities/comment/api/queryKey.ts
@@ -1,4 +1,5 @@
 export const COMMENT_QUERY_KEY = {
-  all: ['comments'] as const,
-  detail: (id: string) => [...COMMENT_QUERY_KEY.all, id] as const,
+  all: (course_id: string) => ['course', course_id, 'comments'] as const,
+  detail: (course_id: string, comment_id: string) =>
+    ['course', course_id, 'comments', comment_id] as const,
 }

--- a/src/entities/comment/api/update-comment.ts
+++ b/src/entities/comment/api/update-comment.ts
@@ -19,14 +19,21 @@ export const patchComment = async (
   }
 }
 
-export const useUpdateComment = (id: string) => {
+export const useUpdateComment = (course_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ id, contents }: { id: string; contents: string }) =>
-      patchComment(id, contents),
+    mutationFn: ({
+      comment_id,
+      contents,
+    }: {
+      comment_id: string
+      contents: string
+    }) => patchComment(comment_id, contents),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: COMMENT_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({
+        queryKey: COMMENT_QUERY_KEY.all(course_id),
+      })
     },
   })
 }

--- a/src/entities/course/api/delete-course-like.ts
+++ b/src/entities/course/api/delete-course-like.ts
@@ -12,13 +12,15 @@ export const deleteCourseLike = async (id: string) => {
     throw error
   }
 }
-export const useDeleteCourseLike = (id: string) => {
+export const useDeleteCourseLike = (course_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (id: string) => deleteCourseLike(id),
+    mutationFn: (course_id: string) => deleteCourseLike(course_id),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: COURSE_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({
+        queryKey: COURSE_QUERY_KEY.detail(course_id),
+      })
     },
   })
 }

--- a/src/entities/course/api/delete-course.ts
+++ b/src/entities/course/api/delete-course.ts
@@ -16,11 +16,11 @@ export const useDeleteCourse = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (id: string) => deleteCourse(id),
+    mutationFn: (course_id: string) => deleteCourse(course_id),
     onSuccess: () => {
       queryClient.refetchQueries({
         predicate: (query) =>
-          query.queryKey[0] === 'courses' ||
+          (query.queryKey[0] === 'courses' && query.queryKey[1] === 'RECENT') ||
           query.queryKey[0] === 'userCourses',
       })
     },

--- a/src/entities/course/api/get-course.ts
+++ b/src/entities/course/api/get-course.ts
@@ -14,13 +14,10 @@ export const getCourse = async (id: string): Promise<CourseType> => {
   }
 }
 
-export const useGetCourse = (
-  id: string,
-  enabled: boolean = true
-) => {
+export const useGetCourse = (course_id: string, enabled: boolean = true) => {
   return useQuery({
-    queryKey: COURSE_QUERY_KEY.detail(id),
-    queryFn: () => getCourse(id),
-    enabled
+    queryKey: COURSE_QUERY_KEY.detail(course_id),
+    queryFn: () => getCourse(course_id),
+    enabled,
   })
 }

--- a/src/entities/course/api/get-courses.ts
+++ b/src/entities/course/api/get-courses.ts
@@ -43,7 +43,7 @@ export const useGetCourses = (params: {
   return useQuery({
     queryKey: COURSE_QUERY_KEY.all(params),
     queryFn: () => getCourses(params),
-    staleTime: 0,
-    gcTime: 0,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
   })
 }

--- a/src/entities/course/api/post-course-like.ts
+++ b/src/entities/course/api/post-course-like.ts
@@ -13,13 +13,15 @@ export const postCourseLike = async (id: string) => {
   }
 }
 
-export const usePostCourseLike = (id: string) => {
+export const usePostCourseLike = (course_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (id: string) => postCourseLike(id),
+    mutationFn: (course_id: string) => postCourseLike(course_id),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: COURSE_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({
+        queryKey: COURSE_QUERY_KEY.detail(course_id),
+      })
     },
   })
 }

--- a/src/entities/course/api/post-course.ts
+++ b/src/entities/course/api/post-course.ts
@@ -1,5 +1,4 @@
 import { customAxios } from '@/src/shared/api'
-import { COURSE_QUERY_KEY } from './queryKey'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { CoursePayloadType } from '../model'
 import { COURSE_URL } from './endpoint'
@@ -22,7 +21,7 @@ export const usePostCourse = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         predicate: (query) =>
-          query.queryKey[0] === 'courses' ||
+          (query.queryKey[0] === 'courses' && query.queryKey[1] === 'RECENT') ||
           query.queryKey[0] === 'userCourses',
       })
     },

--- a/src/entities/course/api/queryKey.ts
+++ b/src/entities/course/api/queryKey.ts
@@ -14,6 +14,6 @@ export const COURSE_QUERY_KEY = {
       params.primary_region,
       params.secondary_region,
     ] as const,
-  detail: (id: string) => ['course', id] as const,
+  detail: (course_id: string) => ['course', course_id] as const,
   post: ['course', 'post'] as const,
 }

--- a/src/entities/course/api/update-course.ts
+++ b/src/entities/course/api/update-course.ts
@@ -20,13 +20,15 @@ export const patchCourse = async (
   }
 }
 
-export const useUpdateCourse = (id: string) => {
+export const useUpdateCourse = (course_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (data: CoursePayloadType) => patchCourse(id, data),
+    mutationFn: (data: CoursePayloadType) => patchCourse(course_id, data),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: COURSE_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({
+        queryKey: COURSE_QUERY_KEY.detail(course_id),
+      })
     },
   })
 }

--- a/src/entities/place/api/delete-place-review.ts
+++ b/src/entities/place/api/delete-place-review.ts
@@ -12,13 +12,18 @@ export const deletePlaceReview = async (id: string) => {
     throw error
   }
 }
-export const useDeletePlaceReview = (id: string) => {
+export const useDeletePlaceReview = (place_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (id: string) => deletePlaceReview(id),
+    mutationFn: (review_id: string) => deletePlaceReview(review_id),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: PLACE_QUERY_KEY.reviews(id) })
+      queryClient.refetchQueries({
+        queryKey: PLACE_QUERY_KEY.reviews(place_id),
+      })
+      queryClient.refetchQueries({
+        queryKey: PLACE_QUERY_KEY.detail(place_id),
+      })
     },
   })
 }

--- a/src/entities/place/api/get-place-review.ts
+++ b/src/entities/place/api/get-place-review.ts
@@ -12,10 +12,10 @@ export const getPlaceReview = async (id: string): Promise<PlaceReviewType> => {
     throw error
   }
 }
-export const useGetPlaceReview = (id?: string) => {
+export const useGetPlaceReview = (review_id?: string) => {
   return useQuery({
-    enabled: Boolean(id),
-    queryKey: ['placeReview', id],
-    queryFn: () => getPlaceReview(id!),
+    enabled: Boolean(review_id),
+    queryKey: ['placeReview', review_id],
+    queryFn: () => getPlaceReview(review_id!),
   })
 }

--- a/src/entities/place/api/get-place-reviews.ts
+++ b/src/entities/place/api/get-place-reviews.ts
@@ -16,10 +16,9 @@ export const getPlaceReviews = async (
   }
 }
 
-export const useGetPlaceReviews = (id: string) => {
+export const useGetPlaceReviews = (place_id: string) => {
   return useQuery({
-    queryKey: PLACE_QUERY_KEY.reviews(id),
-    queryFn: () => getPlaceReviews(id),
-    gcTime: 0,
+    queryKey: PLACE_QUERY_KEY.reviews(place_id),
+    queryFn: () => getPlaceReviews(place_id),
   })
 }

--- a/src/entities/place/api/get-place.ts
+++ b/src/entities/place/api/get-place.ts
@@ -13,9 +13,9 @@ export const getPlace = async (id: string): Promise<PlaceType> => {
     throw error
   }
 }
-export const useGetPlace = (id: string) => {
+export const useGetPlace = (place_id: string) => {
   return useQuery({
-    queryKey: PLACE_QUERY_KEY.detail(id),
-    queryFn: () => getPlace(id),
+    queryKey: PLACE_QUERY_KEY.detail(place_id),
+    queryFn: () => getPlace(place_id),
   })
 }

--- a/src/entities/place/api/post-place-review.ts
+++ b/src/entities/place/api/post-place-review.ts
@@ -20,13 +20,18 @@ export const postPlaceReview = async (
   }
 }
 
-export const usePostPlaceReview = (id: string) => {
+export const usePostPlaceReview = (place_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (data: ReviewPayloadType) => postPlaceReview(id, data),
+    mutationFn: (data: ReviewPayloadType) => postPlaceReview(place_id, data),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: PLACE_QUERY_KEY.reviews(id) })
+      queryClient.refetchQueries({
+        queryKey: PLACE_QUERY_KEY.reviews(place_id),
+      })
+      queryClient.refetchQueries({
+        queryKey: PLACE_QUERY_KEY.detail(place_id),
+      })
     },
   })
 }

--- a/src/entities/place/api/queryKey.ts
+++ b/src/entities/place/api/queryKey.ts
@@ -1,5 +1,7 @@
 export const PLACE_QUERY_KEY = {
   all: ['places'] as const,
-  detail: (id: string) => ['place', id] as const,
-  reviews: (id: string) => ['place', id, 'reviews'] as const,
+  detail: (place_id: string) => ['place', place_id] as const,
+  reviews: (place_id: string) => ['place', place_id, 'reviews'] as const,
+  review: (place_id: string, review_id: string) =>
+    ['place', place_id, 'review', review_id] as const,
 }

--- a/src/entities/place/api/update-place-review.ts
+++ b/src/entities/place/api/update-place-review.ts
@@ -20,12 +20,14 @@ export const updatePlaceReview = async (
   }
 }
 
-export const useUpdatePlaceReview = (id: string) => {
+export const useUpdatePlaceReview = (place_id: string, review_id: string) => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (data: ReviewPayloadType) => updatePlaceReview(id, data),
+    mutationFn: (data: ReviewPayloadType) => updatePlaceReview(review_id, data),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: PLACE_QUERY_KEY.reviews(id) })
+      queryClient.refetchQueries({
+        queryKey: PLACE_QUERY_KEY.review(place_id, review_id),
+      })
     },
   })
 }

--- a/src/entities/plan/api/delete-plan.ts
+++ b/src/entities/plan/api/delete-plan.ts
@@ -17,7 +17,7 @@ export const useDeletePlan = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (id: string) => deletePlan(id),
+    mutationFn: (plan_id: string) => deletePlan(plan_id),
     onSuccess: () => {
       queryClient.refetchQueries({ queryKey: PLAN_QUERY_KEY.all })
     },

--- a/src/entities/plan/api/get-plan.ts
+++ b/src/entities/plan/api/get-plan.ts
@@ -13,13 +13,10 @@ export const getPlan = async (id: string) => {
   }
 }
 
-export const useGetPlan = (
-  id: string,
-  enabled: boolean = true
-) => {
+export const useGetPlan = (plan_id: string, enabled: boolean = true) => {
   return useQuery({
-    queryKey: PLAN_QUERY_KEY.detail(id),
-    queryFn: () => getPlan(id),
-    enabled
+    queryKey: PLAN_QUERY_KEY.detail(plan_id),
+    queryFn: () => getPlan(plan_id),
+    enabled,
   })
 }

--- a/src/entities/plan/api/get-plans.ts
+++ b/src/entities/plan/api/get-plans.ts
@@ -16,5 +16,6 @@ export const useGetPlans = () => {
   return useQuery({
     queryKey: PLAN_QUERY_KEY.all,
     queryFn: () => getPlans(),
+    refetchOnMount: true,
   })
 }

--- a/src/entities/plan/api/queryKey.ts
+++ b/src/entities/plan/api/queryKey.ts
@@ -1,4 +1,4 @@
 export const PLAN_QUERY_KEY = {
   all: ['plans'] as const,
-  detail: (id: string) => ['plan', id] as const,
+  detail: (plan_id: string) => ['plan', plan_id] as const,
 }

--- a/src/entities/plan/api/update-plan.ts
+++ b/src/entities/plan/api/update-plan.ts
@@ -14,13 +14,14 @@ export const updatePlan = async (id: string, payload: PlanPayloadType) => {
   }
 }
 
-export const useUpdatePlan = (id: string) => {
+export const useUpdatePlan = (plan_id: string) => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (data: PlanPayloadType) => updatePlan(id, data),
+    mutationFn: (data: PlanPayloadType) => updatePlan(plan_id, data),
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: PLAN_QUERY_KEY.detail(id) })
+      queryClient.refetchQueries({ queryKey: PLAN_QUERY_KEY.detail(plan_id) })
+      queryClient.invalidateQueries({ queryKey: PLAN_QUERY_KEY.all })
     },
   })
 }

--- a/src/features/comment-card/comment-card.tsx
+++ b/src/features/comment-card/comment-card.tsx
@@ -18,6 +18,7 @@ type CommentCardProps = {
   content: CommentType
   refetch?: () => void
   showKebab: boolean
+  courseId: string
 }
 
 export function CommentCard({
@@ -25,6 +26,7 @@ export function CommentCard({
   content,
   refetch,
   showKebab,
+  courseId,
 }: CommentCardProps) {
   const { writer, contents, created_at } = content
   const { user } = useUserStore()
@@ -46,8 +48,8 @@ export function CommentCard({
     },
   })
 
-  const { mutate: updateComment } = useUpdateComment(id)
-  const { mutate: deleteComment } = useDeleteComment(id)
+  const { mutate: updateComment } = useUpdateComment(courseId)
+  const { mutate: deleteComment } = useDeleteComment(courseId)
 
   const onSubmit = async (data: { contents: string }) => {
     if (!isDirty) {
@@ -57,7 +59,7 @@ export function CommentCard({
 
     try {
       updateComment(
-        { id: id.toString(), contents: data.contents },
+        { comment_id: id.toString(), contents: data.contents },
         {
           onSuccess: () => {
             setErrorMessage('')

--- a/src/features/place-review/review-card.tsx
+++ b/src/features/place-review/review-card.tsx
@@ -29,7 +29,7 @@ export function PlaceReviewCard({
   const [isImageViewOpened, setIsImageViewOpened] = useState(false)
   const [imageIndex, setImageIndex] = useState<number>(0)
 
-  const { mutate: deletePlaceReview } = useDeletePlaceReview(id.toString())
+  const { mutate: deletePlaceReview } = useDeletePlaceReview(placeId)
   const handleDelete = () => {
     try {
       deletePlaceReview(id.toString(), {

--- a/src/views/detail-course/index.tsx
+++ b/src/views/detail-course/index.tsx
@@ -103,6 +103,7 @@ export default function DetailCourse({ courseId }: DetailCourseProps) {
                     content={comment}
                     refetch={refetch}
                     showKebab={false}
+                    courseId={courseId}
                   />
                 )
               })}

--- a/src/views/list-comment/index.tsx
+++ b/src/views/list-comment/index.tsx
@@ -13,7 +13,7 @@ export default function DetailComment({ courseId }: { courseId: string }) {
   const { token } = useAuth()
 
   const { data: comments, isLoading, refetch } = useGetComments(courseId)
-  const { mutate: createComment } = usePostComment()
+  const { mutate: createComment } = usePostComment(courseId)
   const {
     register,
     handleSubmit,
@@ -33,7 +33,7 @@ export default function DetailComment({ courseId }: { courseId: string }) {
 
     try {
       createComment(
-        { id: courseId, contents: data.contents },
+        { course_id: courseId, contents: data.contents },
         {
           onSuccess: () => {
             reset()
@@ -73,6 +73,7 @@ export default function DetailComment({ courseId }: { courseId: string }) {
               content={comment}
               refetch={refetch}
               showKebab={true}
+              courseId={courseId}
             />
           )
         })}

--- a/src/widgets/review-form-layout/index.tsx
+++ b/src/widgets/review-form-layout/index.tsx
@@ -45,7 +45,8 @@ export default function ReviewFormLayout({
   const { data: reviewData } = useGetPlaceReview(reviewId)
   const { mutateAsync: createPlaceMutate } = usePostPlaceReview(placeId)
   const { mutateAsync: updatePlaceMutate } = useUpdatePlaceReview(
-    reviewId ?? ''
+    placeId,
+    reviewId ? reviewId : ''
   )
   const router = useRouter()
 


### PR DESCRIPTION
## 📝 개요

- 플랜 생성 후 플랜 목록이 업데이트 되지 않는 문제를 해결했습니다.
- 기존 코드에서는 모든 react query 훅에서 props들이 id라는 인자로 사용되고 있어, 이로 인한 혼동을 제거하기 위해 수정했습니다.

## ✨ 변경 사항

  - ✨ API 훅 전반의 파라미터 네이밍 통일
  - ✨ 쿼리 키 분리
  - ✨ staleTime, gcTime 제거 및 refetchOnMount, refetchOnWindowFocus 명시적 설정

## 🔗 관련 이슈

closes #284

## 📸 스크린샷 (옵션)

-

## ℹ️ 참고 사항
-