### PR TITLE
[수정] 코스 작성 페이지의 지역 정보 적용 로직 수정

### DIFF
--- a/src/views/list-course/main-course.tsx
+++ b/src/views/list-course/main-course.tsx
@@ -32,7 +32,6 @@ export default function MainCourse() {
 
   useEffect(() => {
     document.body.style.overflow = isLoading ? 'hidden' : 'unset'
-    setSelectedRegion([])
   }, [isLoading])
 
   useEffect(() => {

--- a/src/views/list-course/region-course.tsx
+++ b/src/views/list-course/region-course.tsx
@@ -21,7 +21,8 @@ export default function RegionCourse({
 }: RegionCourseProps) {
   const [isListView, setIsListView] = useState(true)
   const [order, setOrder] = useState<'RECENT' | 'POPULAR'>('RECENT')
-  const { likedRegions, addLikedRegion, removeLikedRegion } = useRegionStore()
+  const { likedRegions, addLikedRegion, removeLikedRegion, setSelectedRegion } =
+    useRegionStore()
   const [isLiked, setIsLiked] = useState(false)
   const [category, setCategory] = useState<string[]>(['ALL'])
   const { show } = useToast()
@@ -42,6 +43,12 @@ export default function RegionCourse({
     const isListView = sessionStorage.getItem('is-list')
     if (isListView) {
       setIsListView(isListView === 'true')
+    }
+
+    setSelectedRegion([primary, secondary])
+
+    return () => {
+      setSelectedRegion([])
     }
   }, [])
 
@@ -137,12 +144,12 @@ export default function RegionCourse({
 
 const findLikedRegionId = (
   likedRegions: LikeRegion[],
-  currentRegion: string[]
+  selectedRegion: string[]
 ): string => {
   const matchedRegion = likedRegions.find(
     (region) =>
-      region.primary_region === currentRegion[0] &&
-      region.secondary_region === currentRegion[1]
+      region.primary_region === selectedRegion[0] &&
+      region.secondary_region === selectedRegion[1]
   )
 
   return matchedRegion ? matchedRegion.id : ''

--- a/src/widgets/course-plan-form-layout/index.tsx
+++ b/src/widgets/course-plan-form-layout/index.tsx
@@ -25,6 +25,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query'
 import { useToast } from '@/src/shared/provider'
 import useUserStore from '@/src/shared/store/userStore'
+import useRegionStore from '@/src/shared/store/regionStore'
 
 const LAYOUT_TYPE = {
   course: 'course' as const,
@@ -63,6 +64,7 @@ export default function CoursePlanFormLayout({
   const router = useRouter()
   const queryClient = useQueryClient()
   const { show } = useToast()
+  const { setSelectedRegion } = useRegionStore()
 
   const [places, setPlaces] = useState<CoursePlanPlaceType[]>([])
   const [openSearchPlace, setOpenSearchPlace] = useState<boolean>(false)
@@ -111,11 +113,11 @@ export default function CoursePlanFormLayout({
       contents,
       visit_date,
       places,
-      writer,
     } = fetchData
+    const writer = 'writer' in fetchData && fetchData.writer
 
     const { user } = useUserStore.getState()
-    if (!user || writer.id !== user?.user_id) {
+    if (writer && (!user || writer.id !== user?.user_id)) {
       router.push(`/${type}s/${id}`)
       show('warning', '수정 권한이 없습니다.')
       return
@@ -205,6 +207,12 @@ export default function CoursePlanFormLayout({
       places.map((place) => place.id.toString())
     )
   }, [places])
+
+  useEffect(() => {
+    return () => {
+      setSelectedRegion([])
+    }
+  }, [])
 
   const onSubmit = async (data: PayloadType) => {
     try {


### PR DESCRIPTION
## 📝 개요

- 코스 작성 페이지에서 지역 정보가 잘못 적용되는 문제를 해결했습니다.
    - 이전에 검색했던 지역 정보가 남아있어, 잘못 적용되는 문제
    - 뒤로가기 이후 재접속 시 지역 정보가 적용되지 않는 문제

## ✨ 변경 사항

- 코드나 기능의 주요 변경 사항을 설명합니다.

  - ✨ `currentRegion` -> `selectedRegion` 용어 통일
  - ✨ selectedRegion의 초기화 시점 변경

## 🔗 관련 이슈

- closes #282 

## 📸 스크린샷 (옵션)


https://github.com/user-attachments/assets/9a69ad06-acd3-401b-9218-02b4e91826dc



## ℹ️ 참고 사항

- 플랜 수정 시 writer 정보 누락으로 인해 렌더링 오류가 발생하는 문제를 해결했습니다. 이 오류는 `CoursePlanFormLayout`을 호출하는 코스 작성/수정 페이지에도 영향을 미쳐 함께 수정했습니다.
- 이 오류를 제외한 다른 플랜 관련 버그는 더 이상 수정하지 않을 예정입니다.