### PR TITLE
[리팩토링] 코스 상세 페이지를 위한 레이아웃 추가

### DIFF
--- a/app/courses/[id]/page.tsx
+++ b/app/courses/[id]/page.tsx
@@ -4,10 +4,7 @@ import Link from 'next/link'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Spacer, ProfileImage } from '@/src/shared/ui'
-import {
-  CoursePlanDetailLayout,
-  CoursePlanDetailLayoutSkeleton,
-} from '@/src/widgets'
+import { CourseDetailLayout, CourseDetailLayoutSkeleton } from '@/src/widgets'
 import { formatDateToYYYYMMDD, passFromCreate } from '@/src/shared/utils/date'
 import { useGetCourse } from '@/src/entities/course'
 import { useGetComments, CommentCard } from '@/src/entities/comment'
@@ -52,10 +49,10 @@ export default function Page({ params }: { params: { id: string } }) {
   }
 
   if (isCourseLoading || isCommentLoading || !course || !comments)
-    return <CoursePlanDetailLayoutSkeleton type='course' />
+    return <CourseDetailLayoutSkeleton />
 
   return (
-    <CoursePlanDetailLayout type='course' id={courseId} data={course}>
+    <CourseDetailLayout id={courseId} data={course}>
       <section className='w-full px-[20px] py-[10px] text-white bg-brand'>
         <div className='w-full flex gap-[10px] max-w-[375px] cursor-pointer'>
           <ProfileImage
@@ -125,6 +122,6 @@ export default function Page({ params }: { params: { id: string } }) {
           )}
         </div>
       </div>
-    </CoursePlanDetailLayout>
+    </CourseDetailLayout>
   )
 }

--- a/src/widgets/course-plan-detail-layout/CourseDetailLayout.tsx
+++ b/src/widgets/course-plan-detail-layout/CourseDetailLayout.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { Share2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { ShareModal, PlaceCollapse } from '@/src/features'
+import type { CourseType } from '@/src/entities/course'
+import { CATEGORY } from '@/src/entities/course'
+import { CourseHeader } from '@/src/widgets'
+import useUserStore from '@/src/shared/store/userStore'
+import { PlanType } from '@/src/entities/plan'
+import { Spacer, ActiveKakaoMap, Divider } from '@/src/shared/ui'
+
+interface CourseDetailLayoutProps {
+  id: string
+  children?: React.ReactNode
+  data: CourseType
+}
+
+export function CourseDetailLayout({
+  id,
+  children,
+  data,
+}: CourseDetailLayoutProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const userId = useUserStore((state) => state.user?.user_id)
+  const userName = useUserStore((state) => state.user?.name)
+
+  const isCourseType = (data: CourseType | PlanType) =>
+    'writer' in data && 'is_liked' in data
+
+  const isCourse = useMemo(() => isCourseType(data), [data])
+  const isMine = useMemo(
+    () => (isCourse ? userId === (data as CourseType).writer.id : true),
+    [isCourse, userId, data]
+  )
+
+  return (
+    <>
+      <CourseHeader
+        title={data?.title || ''}
+        id={id}
+        isLiked={isCourseType(data) ? data.is_liked : false}
+        isMine={isMine}
+      />
+      <div
+        className={`w-full flex flex-col ${
+          isCourse ? '' : 'min-h-[calc(100vh-194px)]'
+        }`}
+      >
+        {isCourseType(data) && (
+          <div className='w-full items-center justify-center inline-flex gap-[5px] py-[8px]'>
+            {data?.categories?.map((category, index) => {
+              return (
+                <span
+                  key={index}
+                  className='px-[10px] py-[5px] text-[12px] text-white border rounded-[15px] bg-container-light-blue'
+                >
+                  {CATEGORY[category as keyof typeof CATEGORY]}
+                </span>
+              )
+            })}
+          </div>
+        )}
+
+        {data?.places && data?.places.length > 0 && (
+          <div className='px-[30px]'>
+            <ActiveKakaoMap
+              places={data?.places || []}
+              activeIndex={activeIndex}
+            />
+          </div>
+        )}
+        <Spacer height={16} />
+
+        <p className='px-[50px] text-sub text-[rgba(0,0,0,0.8)]'>
+          <span className='text-brand font-normal'>
+            {isCourseType(data) ? data.writer.name : userName}
+          </span>
+          &nbsp;
+          {isCourse ? '님의 코스 제안이에요.' : '님이 선택한 장소들이에요.'}
+        </p>
+
+        <Spacer height={10} />
+        <PlaceCollapse
+          places={data?.places || []}
+          activeIndex={activeIndex}
+          setActiveIndex={setActiveIndex}
+        />
+
+        <Divider margin={16} />
+
+        <section className='w-full flex flex-col gap-[10px] text-[rgba(0,0,0,0.8)]'>
+          <p className='px-[50px] text-sub'>
+            <span className='text-brand font-normal'>
+              {isCourseType(data) ? data.writer.name : userName}
+            </span>
+            &nbsp;님의 코스 설명이에요.
+          </p>
+          <span className='text-middle mx-[30px] px-[14px] py-[10px] bg-bright-gray rounded-[10px] whitespace-pre-line'>
+            {data?.contents || ''}
+          </span>
+        </section>
+
+        <Divider margin={16} />
+
+        <section className='w-full flex flex-col gap-[10px] text-[rgba(0,0,0,0.8)]'>
+          <p className='px-[50px] text-sub'>
+            <span className='text-brand font-normal'>
+              {isCourseType(data) ? data.writer.name : userName}
+            </span>
+            &nbsp;님이 방문한 날짜에요.
+          </p>
+          <span className='text-middle flex items-center justify-center mx-[30px] px-[14px] py-[10px] bg-bright-gray rounded-full opacity-80'>
+            {data?.visit_date || ''}
+          </span>
+        </section>
+        <Spacer height={16} />
+      </div>
+
+      {children}
+
+      <Spacer height={25} />
+      {!isCourse && (
+        <button
+          className='group w-full max-w-[375px] h-[54px] text-gray-600 font-bold text-main flex items-center justify-center bg-light-gray gap-[10px] hover:bg-brand hover:text-white transition-all duration-200 fixed bottom-60'
+          onClick={() => setIsModalOpen(true)}
+        >
+          <Share2
+            size={24}
+            strokeWidth={1.5}
+            className='fill-gray-600 group-hover:fill-white transition-colors duration-200'
+          />
+          공유하기
+        </button>
+      )}
+
+      <ShareModal
+        type='plan'
+        isOpen={isModalOpen}
+        setIsOpen={setIsModalOpen}
+        data={data}
+      />
+    </>
+  )
+}

--- a/src/widgets/course-plan-detail-layout/CourseDetailLayoutSkeleton.tsx
+++ b/src/widgets/course-plan-detail-layout/CourseDetailLayoutSkeleton.tsx
@@ -1,0 +1,63 @@
+import { Spacer, Divider, DivSkeleton } from '@/src/shared/ui'
+import { CourseHeader } from '../header'
+
+export function CourseDetailLayoutSkeleton() {
+  return (
+    <>
+      <CourseHeader title={''} id={''} isLiked={false} isMine={false} />
+      <div className='w-full flex flex-col px-[30px]'>
+        <div className='w-full items-center justify-center inline-flex gap-[5px] py-[8px]'>
+          {Array.from({ length: 3 }, (_, index) => (
+            <DivSkeleton
+              key={index}
+              height={30}
+              width={50}
+              className='px-[10px] py-[5px] text-[12px] text-white border rounded-[15px] bg-container-light-blue'
+            />
+          ))}
+        </div>
+
+        <DivSkeleton height={180} width={315} className='rounded-[10px]' />
+        <Spacer height={16} />
+
+        <div className='flex flex-row text-sub text-[rgba(0,0,0,0.8)]'>
+          <DivSkeleton height={20} width={30} />
+          &nbsp; 님의 코스 제안이에요.
+        </div>
+
+        <Spacer height={10} />
+        {Array.from({ length: 3 }, (_, index) => (
+          <DivSkeleton
+            key={index}
+            height={30}
+            width={315}
+            className='my-[5px] text-[12px] text-white border rounded-[15px] bg-container-light-blue'
+          />
+        ))}
+
+        <Divider margin={16} />
+
+        <section className='w-full flex flex-col gap-[10px] text-[rgba(0,0,0,0.8)]'>
+          <div className='flex flex-row text-sub'>
+            <DivSkeleton height={20} width={30} />
+            &nbsp;님의 코스 설명이에요.
+          </div>
+          <DivSkeleton height={100} width={315} className='rounded-[10px]' />
+        </section>
+
+        <Divider margin={16} />
+
+        <section className='w-full flex flex-col gap-[10px] text-[rgba(0,0,0,0.8)]'>
+          <div className='flex flex-row text-sub'>
+            <DivSkeleton height={20} width={30} />
+            &nbsp;님이 방문한 날짜에요.
+          </div>
+          <DivSkeleton height={40} width={315} className='rounded-full' />
+        </section>
+        <Spacer height={16} />
+      </div>
+
+      <Spacer height={25} />
+    </>
+  )
+}

--- a/src/widgets/course-plan-detail-layout/index.ts
+++ b/src/widgets/course-plan-detail-layout/index.ts
@@ -1,2 +1,4 @@
 export * from './CoursePlanDetailLayoutSkeleton'
 export * from './CoursePlanDetailLayout'
+export * from './CourseDetailLayout'
+export * from './CourseDetailLayoutSkeleton'

--- a/src/widgets/header/CourseHeader.tsx
+++ b/src/widgets/header/CourseHeader.tsx
@@ -1,19 +1,19 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import React from 'react'
 import useUserStore from '@/src/shared/store/userStore'
 import { useQueryClient } from '@tanstack/react-query'
 import { BackButton } from '@/src/shared/ui'
 import {
   useDeleteCourse,
-  useUnlikeCourse,
-  useLikeCourse,
+  useDeleteCourseLike,
+  usePostCourseLike,
 } from '@/src/entities/course'
 import { USER_QUERY_KEY } from '@/src/entities/user/api'
 import { HeaderBase, TitleWithTagStyle, ActionDropdown } from '@/src/features'
-import { useAuth, useToast } from '@/src/shared/providers'
+import { useAuth, useToast } from '@/src/shared/provider'
 import heart_fill from '@/src/assets/icon/heart_fullfill_20.svg'
 import heart_empty from '@/src/assets/icon/heart_empty_20.svg'
 import Image from 'next/image'
@@ -37,8 +37,8 @@ export function CourseHeader({
   const { show } = useToast()
   const { token } = useAuth()
 
-  const { mutate: unlikeCourse } = useUnlikeCourse(id)
-  const { mutate: likeCourse } = useLikeCourse(id)
+  const { mutate: unlikeCourse } = useDeleteCourseLike(id)
+  const { mutate: likeCourse } = usePostCourseLike(id)
   const { mutate: deleteCourse } = useDeleteCourse()
 
   const myId = useUserStore((state) => state.user?.user_id)
@@ -56,10 +56,10 @@ export function CourseHeader({
     try {
       if (isLiked) {
         setClickedLike(false)
-        unlikeCourse(undefined)
+        unlikeCourse(id)
       } else {
         setClickedLike(true)
-        likeCourse(undefined)
+        likeCourse(id)
       }
     } catch (error) {
       console.error(error)

--- a/src/widgets/header/CourseHeader.tsx
+++ b/src/widgets/header/CourseHeader.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import React from 'react'
+import useUserStore from '@/src/shared/store/userStore'
+import { useQueryClient } from '@tanstack/react-query'
+import { BackButton } from '@/src/shared/ui'
+import {
+  useDeleteCourse,
+  useUnlikeCourse,
+  useLikeCourse,
+} from '@/src/entities/course'
+import { USER_QUERY_KEY } from '@/src/entities/user/api'
+import { HeaderBase, TitleWithTagStyle, ActionDropdown } from '@/src/features'
+import { useAuth, useToast } from '@/src/shared/providers'
+import heart_fill from '@/src/assets/icon/heart_fullfill_20.svg'
+import heart_empty from '@/src/assets/icon/heart_empty_20.svg'
+import Image from 'next/image'
+
+interface CourseHeaderProps {
+  title: string
+  id: string
+  isMine: boolean
+  isLiked: boolean
+}
+
+export function CourseHeader({
+  title,
+  id,
+  isMine,
+  isLiked,
+}: CourseHeaderProps) {
+  const [clickedLike, setClickedLike] = useState(isLiked)
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { show } = useToast()
+  const { token } = useAuth()
+
+  const { mutate: unlikeCourse } = useUnlikeCourse(id)
+  const { mutate: likeCourse } = useLikeCourse(id)
+  const { mutate: deleteCourse } = useDeleteCourse()
+
+  const myId = useUserStore((state) => state.user?.user_id)
+
+  // TODO: userstore 동기화 되느지 확인
+
+  const handleClickBack = () => router.back()
+
+  const handleClickLike = async () => {
+    if (!token) {
+      show('warning', '로그인 후 이용해주세요')
+      return
+    }
+
+    try {
+      if (isLiked) {
+        setClickedLike(false)
+        unlikeCourse(undefined)
+      } else {
+        setClickedLike(true)
+        likeCourse(undefined)
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  const handleDelete = async () => {
+    try {
+      if (myId) {
+        deleteCourse(id, {
+          onSuccess: () => {
+            router.back()
+            queryClient.invalidateQueries({
+              queryKey: USER_QUERY_KEY.courses(myId, 'RECENT'),
+            })
+          },
+        })
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  return (
+    <HeaderBase className='px-[20px]'>
+      <div className='flex items-center gap-[10px]'>
+        <BackButton onClick={handleClickBack} />
+      </div>
+
+      <TitleWithTagStyle title={title} />
+
+      <div className='flex items-center gap-[10px]'>
+        {isMine ? (
+          <ActionDropdown type='course' id={id} handleDelete={handleDelete} />
+        ) : (
+          <Image
+            src={clickedLike ? (heart_fill as string) : (heart_empty as string)}
+            alt='heart'
+            className='cursor-pointer'
+            onClick={handleClickLike}
+            width={20}
+            height={20}
+          />
+        )}
+      </div>
+    </HeaderBase>
+  )
+}

--- a/src/widgets/header/index.ts
+++ b/src/widgets/header/index.ts
@@ -1,3 +1,4 @@
 export * from './CoursePlanHeader'
 export * from './MainHeader'
 export * from './ActionHeader'
+export * from './CourseHeader'


### PR DESCRIPTION
## 📝 개요

 - Course 상세 페이지에서 사용하는 레이아웃 컴포넌트를 리팩토링했습니다.
- 기존 CoursePlanDetailLayout을 대체할 CourseDetailLayout 컴포넌트를 새로 추가했습니다.

 
## ✨ 변경 사항

- ✨ CourseDetailLayout 컴포넌트 신규 추가 - Course 전용 상세 레이아웃
- ✨ CourseDetailLayoutSkeleton 컴포넌트 추가 - 로딩 상태 UI
- ✨ CourseHeader 컴포넌트 추가 - Course 상세 페이지 전용 헤더
- ✨ app/courses/[id]/page.tsx에서 새 레이아웃 컴포넌트 적용

## 🔗 관련 이슈

-

## 📸 스크린샷 (옵션)

-

## ℹ️ 참고 사항

-
