### PR TITLE
[수정] 코스 생성 시 백엔드 API 응답 타입 불일치 오류 해결

### DIFF
--- a/src/entities/course/model/course.type.ts
+++ b/src/entities/course/model/course.type.ts
@@ -1,5 +1,5 @@
 import type { WriterType } from '@/src/entities/user/model/type'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 
 export type FavoriteRegionType = {
   id: number
@@ -17,7 +17,7 @@ export type CourseType = {
   comments: number
   likes: number
   created_at: string
-  places: CoursePlanPlaceType[]
+  places: CoursePlaceType[]
   writer: WriterType
   is_liked: boolean
   visit_date: string
@@ -39,6 +39,6 @@ export type CourseInputType = {
   secondary_region: string
   categories: string[]
   contents: string
-  places: CoursePlanPlaceType[]
+  places: CoursePlaceType[]
   visit_date: string
 }

--- a/src/entities/course/model/mock.data.ts
+++ b/src/entities/course/model/mock.data.ts
@@ -13,7 +13,7 @@ export const mockCourse = {
   places: [
     {
       order: 0,
-      id: 1,
+      id: '1',
       name: '강남김밥',
       latitude: '37.51647777507762',
       longitude: '127.04264755226313',

--- a/src/entities/place/model/type.ts
+++ b/src/entities/place/model/type.ts
@@ -45,8 +45,8 @@ export type SeoulType = {
   children?: SeoulType[]
 }
 
-export type CoursePlanPlaceType = {
-  id: number
+export type CoursePlaceType = {
+  id: string
   order: number
   name: string
   latitude: string

--- a/src/entities/place/ui/DragPlaceItem.tsx
+++ b/src/entities/place/ui/DragPlaceItem.tsx
@@ -2,13 +2,13 @@
 
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { CoursePlanPlaceType } from '@/src/entities/place'
+import { CoursePlaceType } from '@/src/entities/place'
 import { AlignJustify, X } from 'lucide-react'
 
 interface DragPlaceItemProps {
-  id: number
-  place: CoursePlanPlaceType
-  onDelete: (id: number) => void
+  id: string
+  place: CoursePlaceType
+  onDelete: (id: string) => void
 }
 
 export default function DragPlaceItem({

--- a/src/entities/plan/model/type.ts
+++ b/src/entities/plan/model/type.ts
@@ -1,4 +1,4 @@
-import { CoursePlanPlaceType } from '@/src/entities/place'
+import { CoursePlaceType } from '@/src/entities/place'
 
 export type PlanType = {
   id: number
@@ -7,7 +7,7 @@ export type PlanType = {
   primary_region: string
   secondary_region: string
   visit_date: string
-  places: CoursePlanPlaceType[]
+  places: CoursePlaceType[]
 }
 
 export type PlanPayloadType = {

--- a/src/features/course-detail/Places.tsx
+++ b/src/features/course-detail/Places.tsx
@@ -1,4 +1,4 @@
-import { CoursePlanPlaceType, PlaceCollapse } from '@/src/entities/place'
+import { CoursePlaceType, PlaceCollapse } from '@/src/entities/place'
 import { ActiveKakaoMap } from '@/src/shared/ui'
 import { useState } from 'react'
 
@@ -6,7 +6,7 @@ export function Places({
   places,
   username,
 }: {
-  places: CoursePlanPlaceType[]
+  places: CoursePlaceType[]
   username: string
 }) {
   const [activeIndex, setActiveIndex] = useState<number | null>(null)

--- a/src/features/course-form/CourseForm.tsx
+++ b/src/features/course-form/CourseForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Dispatch, SetStateAction } from 'react'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 import {
   Section,
   FormTitle,
@@ -26,8 +26,8 @@ function CourseFormStepOne({
   handleClickSearchPlace,
   showValidation,
 }: {
-  places: CoursePlanPlaceType[]
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  places: CoursePlaceType[]
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   handleClickSearchPlace: () => void
   showValidation: boolean
 }) {
@@ -92,8 +92,8 @@ function CourseFormStepThree() {
 
 interface CourseFormProps {
   step: 'first' | 'second' | 'preview'
-  places: CoursePlanPlaceType[]
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  places: CoursePlaceType[]
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   handleClickSearchPlace: () => void
   showValidationByStep: {
     first: boolean

--- a/src/features/course-form/CourseFormLegacy.tsx
+++ b/src/features/course-form/CourseFormLegacy.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from 'react'
 import { Spacer, Divider } from '@/src/shared/ui'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 import {
   Section,
   FormTitle,
@@ -19,8 +19,8 @@ export function CourseFormLegacy({
   isSubmitted,
 }: {
   pageType: string
-  places: CoursePlanPlaceType[]
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  places: CoursePlaceType[]
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   handleClickSearchPlace: () => void
   isSubmitted: boolean
 }) {

--- a/src/features/course-form/elements-legacy/FormPlaces.tsx
+++ b/src/features/course-form/elements-legacy/FormPlaces.tsx
@@ -1,5 +1,5 @@
 import { CoursePayloadType } from '@/src/entities/course'
-import { CoursePlanPlaceType } from '@/src/entities/place'
+import { CoursePlaceType } from '@/src/entities/place'
 import { ActiveKakaoMap, HelperText } from '@/src/shared/ui'
 import { DragPlace } from '@/src/widgets'
 import { Dispatch, SetStateAction } from 'react'
@@ -13,8 +13,8 @@ export function FormPlaces({
   handleClickSearchPlace,
   isSubmitted,
 }: {
-  places: CoursePlanPlaceType[]
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  places: CoursePlaceType[]
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   handleClickSearchPlace: () => void
   isSubmitted: boolean
 }) {

--- a/src/features/course-form/elements-legacy/FormRegion.tsx
+++ b/src/features/course-form/elements-legacy/FormRegion.tsx
@@ -5,14 +5,14 @@ import { useFormContext } from 'react-hook-form'
 import type { CoursePayloadType } from '@/src/entities/course'
 import { HelperText, RegionCascader } from '@/src/shared/ui'
 import { useEffect } from 'react'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 import useRegionStore from '@/src/shared/store/regionStore'
 
 export function FormRegion({
   setPlaces,
   isSubmitted,
 }: {
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   isSubmitted: boolean
 }) {
   const { setValue, watch } = useFormContext<CoursePayloadType>()

--- a/src/features/course-form/elements/FormPlaces.tsx
+++ b/src/features/course-form/elements/FormPlaces.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { CourseInputType } from '@/src/entities/course'
-import { CoursePlanPlaceType } from '@/src/entities/place'
+import { CoursePlaceType } from '@/src/entities/place'
 import { ActiveKakaoMap, HelperText } from '@/src/shared/ui'
 import { DragPlace } from '@/src/widgets'
 import { Dispatch, SetStateAction } from 'react'
@@ -15,8 +15,8 @@ export function FormPlaces({
   handleClickSearchPlace,
   showValidation,
 }: {
-  places: CoursePlanPlaceType[]
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  places: CoursePlaceType[]
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   handleClickSearchPlace: () => void
   showValidation: boolean
 }) {

--- a/src/features/course-form/elements/FormRegion.tsx
+++ b/src/features/course-form/elements/FormRegion.tsx
@@ -5,14 +5,14 @@ import { useFormContext } from 'react-hook-form'
 import type { CourseInputType } from '@/src/entities/course'
 import { HelperText, RegionCascader } from '@/src/shared/ui'
 import { useEffect } from 'react'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 import useRegionStore from '@/src/shared/store/regionStore'
 
 export function FormRegion({
   setPlaces,
   showValidation,
 }: {
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
   showValidation: boolean
 }) {
   const { setValue, watch } = useFormContext<CourseInputType>()

--- a/src/features/place-collapse/PlaceCollapse.tsx
+++ b/src/features/place-collapse/PlaceCollapse.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { ChevronDown, ChevronUp, Copy } from 'lucide-react'
 import logoDefaultCopy from '@/src/assets/images/(logo)/temp_empty.png'
-import { type CoursePlanPlaceType, StarRateView } from '@/src/entities/place'
+import { type CoursePlaceType, StarRateView } from '@/src/entities/place'
 import { Spacer } from '@/src/shared/ui'
 import { useToast } from '@/src/shared/provider'
 import { PlaceReviewLinks } from '@/src/widgets'
@@ -11,7 +11,7 @@ export function PlaceCollapse({
   activeIndex,
   setActiveIndex,
 }: {
-  places: CoursePlanPlaceType[]
+  places: CoursePlaceType[]
   activeIndex: number | null
   setActiveIndex: (key: (prevKey: number | null) => null | number) => void
 }) {

--- a/src/shared/ui/KakaoMap.tsx
+++ b/src/shared/ui/KakaoMap.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import type { CoursePlanPlaceType, KakaoPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType, KakaoPlaceType } from '@/src/entities/place'
 
 interface ActiveKakaoMapProps {
-  places: CoursePlanPlaceType[]
+  places: CoursePlaceType[]
   center?: number[]
   activeIndex?: number | null
 }
@@ -82,7 +82,7 @@ export function ActiveKakaoMap({
     updateMarkers(places)
   }, [places, activeIndex])
 
-  const updateMarkers = (places: CoursePlanPlaceType[]) => {
+  const updateMarkers = (places: CoursePlaceType[]) => {
     const map = mapRef.current
     if (!map) return
 

--- a/src/widgets/course-plan-form-layout/CourseFormLayout.tsx
+++ b/src/widgets/course-plan-form-layout/CourseFormLayout.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useState, useEffect } from 'react'
 import { Spacer } from '@/src/shared/ui'
 import { ActionHeader, SearchPlace } from '@/src/widgets'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 import type { CourseInputType, CoursePayloadType } from '@/src/entities/course'
 import { CourseFormByStep } from '@/src/features'
 import {
@@ -46,7 +46,7 @@ export function CourseFormLayout({ level, id }: CourseFormLayoutProps) {
   const { show } = useToast()
   const { setSelectedRegion } = useRegionStore()
 
-  const [places, setPlaces] = useState<CoursePlanPlaceType[]>([])
+  const [places, setPlaces] = useState<CoursePlaceType[]>([])
   const [openSearchPlace, setOpenSearchPlace] = useState<boolean>(false)
   const [showValidationByStep, setShowValidationByStep] = useState<{
     first: boolean

--- a/src/widgets/course-plan-form-layout/CoursePlanFormLayout.tsx
+++ b/src/widgets/course-plan-form-layout/CoursePlanFormLayout.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/navigation'
 import { useState, useEffect, useMemo } from 'react'
 import { Spacer } from '@/src/shared/ui'
 import { ActionHeader, SearchPlace } from '@/src/widgets'
-import type { CoursePlanPlaceType } from '@/src/entities/place'
+import type { CoursePlaceType } from '@/src/entities/place'
 import type { CoursePayloadType } from '@/src/entities/course'
 import {
   PLAN_QUERY_KEY,
@@ -69,7 +69,7 @@ export function CoursePlanFormLayout({
   const { show } = useToast()
   const { setSelectedRegion } = useRegionStore()
 
-  const [places, setPlaces] = useState<CoursePlanPlaceType[]>([])
+  const [places, setPlaces] = useState<CoursePlaceType[]>([])
   const [openSearchPlace, setOpenSearchPlace] = useState<boolean>(false)
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false)
   const [isDataLoaded, setIsDataLoaded] = useState<boolean>(false)

--- a/src/widgets/drag-place/DragPlace.tsx
+++ b/src/widgets/drag-place/DragPlace.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CoursePlanPlaceType } from '@/src/entities/place'
+import { CoursePlaceType } from '@/src/entities/place'
 import { closestCenter, DndContext, DragEndEvent } from '@dnd-kit/core'
 import DragPlaceItem from '@/src/entities/place/ui/DragPlaceItem'
 import {
@@ -11,8 +11,8 @@ import {
 import { Dispatch, SetStateAction, useMemo } from 'react'
 
 interface DragPlaceProps {
-  places: CoursePlanPlaceType[]
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  places: CoursePlaceType[]
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
 }
 
 export function DragPlace({ places, setPlaces }: DragPlaceProps) {
@@ -20,7 +20,7 @@ export function DragPlace({ places, setPlaces }: DragPlaceProps) {
     const { active, over } = event
 
     if (active.id !== over?.id) {
-      setPlaces((items: CoursePlanPlaceType[]) => {
+      setPlaces((items: CoursePlaceType[]) => {
         const oldIndex = items.findIndex((item) => item.id === active.id)
         const newIndex = items.findIndex((item) => item.id === over?.id)
         return arrayMove(items, oldIndex, newIndex)
@@ -28,8 +28,8 @@ export function DragPlace({ places, setPlaces }: DragPlaceProps) {
     }
   }
 
-  const handleDelete = (id: number) => {
-    setPlaces((prev: CoursePlanPlaceType[]) =>
+  const handleDelete = (id: string) => {
+    setPlaces((prev: CoursePlaceType[]) =>
       prev.filter((place) => place.id !== id)
     )
   }

--- a/src/widgets/search-place/SearchPlace.tsx
+++ b/src/widgets/search-place/SearchPlace.tsx
@@ -6,7 +6,7 @@ import { ActionHeader } from '@/src/widgets'
 import {
   getPlaceSearchResult,
   postPlace,
-  CoursePlanPlaceType,
+  CoursePlaceType,
   PlaceSearchType,
 } from '@/src/entities/place'
 import { Search } from 'lucide-react'
@@ -20,7 +20,7 @@ type MetaType = {
 interface SearchPlaceProps {
   region: string
   setOpenSearchPlace: (open: boolean) => void
-  setPlaces: Dispatch<SetStateAction<CoursePlanPlaceType[]>>
+  setPlaces: Dispatch<SetStateAction<CoursePlaceType[]>>
 }
 
 export function SearchPlace({
@@ -51,7 +51,7 @@ export function SearchPlace({
   const selectPlace = async (place: PlaceSearchType) => {
     setOpenSearchPlace(false)
     const placeId = await postPlace(place)
-    const placePayload: CoursePlanPlaceType = {
+    const placePayload: CoursePlaceType = {
       id: placeId.id,
       order: 0,
       name: place.place_name,


### PR DESCRIPTION
## 📝 개요

- 장소 ID 타입을 number에서 string으로 변경하여 백엔드 API 응답과 일치시켰습니다.

## ✨ 변경 사항

- ✨ CoursePlaceType 타입 신규 추가 (id: string)
- ✨ 기존 CoursePlanPlaceType → CoursePlaceType으로 타입 교체
- ✨ 관련 컴포넌트들의 props 타입 업데이트

## 🔗 관련 이슈

-

## 📸 스크린샷 (옵션)

-

## ℹ️ 참고 사항

- CoursePlanPlaceType은 추후 제거 필요
